### PR TITLE
Adding comments to methods

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ lazy val scala211 = "2.11.12"
 
 ThisBuild / scalaVersion := scala212
 
-val scalapbVersion = "0.8.3"
+val scalapbVersion = "0.9.0-M6"
 
 // Cross-compilation does not work for 2.11, haven't found the right combination of (sbt-protoc and sbt) versions
 lazy val codegen = (project in file("codegen"))

--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,6 @@ lazy val scala211 = "2.11.12"
 
 ThisBuild / scalaVersion := scala212
 
-val scalapbVersion = "0.9.0-M6"
-
 // Cross-compilation does not work for 2.11, haven't found the right combination of (sbt-protoc and sbt) versions
 lazy val codegen = (project in file("codegen"))
   .enablePlugins(SbtPlugin, BuildInfoPlugin)
@@ -34,7 +32,7 @@ lazy val runtime = (project in file("runtime")).settings(
   crossScalaVersions := Seq(scala211, scalaVersion.value),
   libraryDependencies ++= Seq(
     "com.twitter" %% "finagle-http" % "19.5.0",
-    "com.thesamet.scalapb" %% "scalapb-runtime" % scalapbVersion,
+    "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion,
     "com.thesamet.scalapb" %% "scalapb-json4s" % "0.7.2",
 
     "org.specs2" %% "specs2-core" % "4.3.6" % Test,

--- a/codegen/src/main/scala/com/soundcloud/twinagle/codegen/TwinagleServicePrinter.scala
+++ b/codegen/src/main/scala/com/soundcloud/twinagle/codegen/TwinagleServicePrinter.scala
@@ -112,7 +112,6 @@ final class TwinagleServicePrinter(service: ServiceDescriptor, implicits: Descri
     val methods = serviceDescriptor.methods
     s"""
        |$docString
-       |
        |trait $serviceName {
        |${methods.map(getServiceMethodDeclaration).mkString("\n")}
        |}
@@ -132,8 +131,9 @@ final class TwinagleServicePrinter(service: ServiceDescriptor, implicits: Descri
     val varName = decapitalize(varType)
     val outputType = methodOutputType(methodDescriptor)
     val methodName = decapitalizedName(methodDescriptor)
+    val docString = commentToDocString(methodDescriptor.comment).replace("\n", "\n  ") // First line is indented by "|  " and the next lines are indented with the replace
     s"""
-       |  ${commentToDocString(methodDescriptor.comment)}
+       |  $docString
        |  def $methodName($varName: $varType): $Future[$outputType]""".stripMargin
   }
 
@@ -217,13 +217,12 @@ final class TwinagleServicePrinter(service: ServiceDescriptor, implicits: Descri
 
   private def commentToDocString(comment: Option[String]) = {
     val docLines: Seq[String] = comment.map(_.split('\n').toSeq).getOrElse(Seq.empty)
-    val docString = if (docLines.nonEmpty) {
+    if (docLines.nonEmpty) {
       s"""/**
          |${docLines.map("  * " + _).mkString("\n")}
          |  */""".stripMargin
     } else {
       ""
     }
-    docString
   }
 }

--- a/codegen/src/sbt-test/generator/e2e/src/main/protobuf/demo.proto
+++ b/codegen/src/sbt-test/generator/e2e/src/main/protobuf/demo.proto
@@ -23,7 +23,7 @@ message BarResp {}
 service Some {
 
   // foo does things with a FooReq
-  rpc Foo(FooReq) returns (FooResp) {}  // foo does things with a FooReq
+  rpc Foo(FooReq) returns (FooResp) {}
 
   // bar does something else
   rpc Bar(BarReq) returns (BarResp) {}   // bar does something else

--- a/codegen/src/sbt-test/generator/e2e/src/main/protobuf/demo.proto
+++ b/codegen/src/sbt-test/generator/e2e/src/main/protobuf/demo.proto
@@ -23,10 +23,10 @@ message BarResp {}
 service Some {
 
   // foo does things with a FooReq
-  rpc Foo(FooReq) returns (FooResp) {}
+  rpc Foo(FooReq) returns (FooResp) {}  // foo does things with a FooReq
 
   // bar does something else
-  rpc Bar(BarReq) returns (BarResp) {}
+  rpc Bar(BarReq) returns (BarResp) {}   // bar does something else
 }
 
 service Other {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,5 +6,5 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 
 libraryDependencies ++= Seq(
   "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value,
-  "com.thesamet.scalapb" %% "compilerplugin" % "0.8.4"
+  "com.thesamet.scalapb" %% "compilerplugin" % "0.9.0-M6"
 )


### PR DESCRIPTION
Using a release candidate version of sbt-protoc, we can add comments to service rpc's and use the built in stuff for the other comments