### PR TITLE
include well-known types by default

### DIFF
--- a/codegen/src/main/scala/com/soundcloud/twinagle/codegen/ServerClientCodeGenerator.scala
+++ b/codegen/src/main/scala/com/soundcloud/twinagle/codegen/ServerClientCodeGenerator.scala
@@ -17,8 +17,8 @@ object ServerClientCodeGenerator extends protocbridge.ProtocCodeGenerator {
   // This would make sbt-protoc append the following artifacts to the user's
   // project.  If you have a runtime library this is the place to specify it.
   override def suggestedDependencies: Seq[protocbridge.Artifact] = Seq(
-    Artifact("com.soundcloud", s"twinagle-runtime_${BuildInfo.scalaBinaryVersion}", BuildInfo.version),
-    Artifact("com.google.protobuf", "protobuf-java", "3.5.1")
+    Artifact("com.soundcloud", s"twinagle-runtime", BuildInfo.version, crossVersion = true),
+    Artifact("com.thesamet.scalapb", "scalapb-runtime", scalapb.compiler.Version.scalapbVersion, crossVersion = true)
   )
 
   def generateServiceFiles(file: FileDescriptor,

--- a/codegen/src/main/scala/com/soundcloud/twinagle/codegen/Twinagle.scala
+++ b/codegen/src/main/scala/com/soundcloud/twinagle/codegen/Twinagle.scala
@@ -5,6 +5,7 @@ import sbtprotoc.ProtocPlugin.autoImport.PB
 import sbt.Keys._
 import sbt._
 import sbt.plugins.JvmPlugin
+import sbtprotoc.ProtocPlugin.ProtobufConfig
 
 object Twinagle extends AutoPlugin {
   override def requires: Plugins = sbtprotoc.ProtocPlugin && JvmPlugin
@@ -16,9 +17,8 @@ object Twinagle extends AutoPlugin {
       Target(scalapb.gen(grpc = false), (sourceManaged in Compile).value),
       Target(JvmGenerator("scala-twinagle", ServerClientCodeGenerator), (sourceManaged in Compile).value)
     ),
-    libraryDependencies ++= List(
-      "com.soundcloud" %% "twinagle-runtime" % com.soundcloud.twinagle.codegen.BuildInfo.version,
-      "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion
+    libraryDependencies ++= Seq(
+      "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion % "protobuf"
     )
   )
 }

--- a/codegen/src/sbt-test/generator/e2e/src/main/protobuf/demo.proto
+++ b/codegen/src/sbt-test/generator/e2e/src/main/protobuf/demo.proto
@@ -2,9 +2,11 @@ syntax = "proto3";
 
 package mygen.protos;
 
+import "google/protobuf/wrappers.proto";
+
 message Person {
   string name = 1;
-  int32 age = 2;
+  google.protobuf.Int32Value age = 2;
 }
 
 // FooReq is an example request


### PR DESCRIPTION
make Twinagle depend `scalapb-runtime` it in the
"protobuf" scope to ensure that it and its
dependencies are available during code generation.

`scalapb-runtime` depends on `protobuf-java`, which
contains the protobuf definitions of the well-known
types[1].

[1]: https://developers.google.com/protocol-buffers/docs/reference/google.protobuf