### PR TITLE
catch exceptions thrown by service implementation

### DIFF
--- a/runtime/src/main/scala/com/soundcloud/twinagle/ServerEndpointBuilder.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/ServerEndpointBuilder.scala
@@ -12,7 +12,7 @@ class ServerEndpointBuilder(extension: EndpointMetadata => Filter.TypeAgnostic) 
       extension(endpointMetadata).toFilter andThen
         new TracingFilter[Request, Response](endpointMetadata) andThen
         new TwirpEndpointFilter[Req, Resp] andThen
-        Service.rescue(Service.mk(rpc))
+        Service.mk(rpc)
     endpointMetadata -> httpService
   }
 }

--- a/runtime/src/main/scala/com/soundcloud/twinagle/ServerEndpointBuilder.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/ServerEndpointBuilder.scala
@@ -6,12 +6,13 @@ import com.twitter.util.Future
 import scalapb.{GeneratedMessage, GeneratedMessageCompanion, Message}
 
 class ServerEndpointBuilder(extension: EndpointMetadata => Filter.TypeAgnostic) {
-  // TODO: refactor types to aliases?
+
   def build[Req <: GeneratedMessage with Message[Req] : GeneratedMessageCompanion, Resp <: GeneratedMessage with Message[Resp] : GeneratedMessageCompanion](rpc: Req => Future[Resp], endpointMetadata: EndpointMetadata): (EndpointMetadata, Service[Request, Response]) = {
     val httpService =
       extension(endpointMetadata).toFilter andThen
         new TracingFilter[Request, Response](endpointMetadata) andThen
-        new ServiceAdapter(rpc)
+        new TwirpEndpointFilter[Req, Resp] andThen
+        Service.rescue(Service.mk(rpc))
     endpointMetadata -> httpService
   }
 }

--- a/runtime/src/test/scala/com/soundcloud/twinagle/ServerEndpointBuilderSpec.scala
+++ b/runtime/src/test/scala/com/soundcloud/twinagle/ServerEndpointBuilderSpec.scala
@@ -1,0 +1,30 @@
+package com.soundcloud.twinagle
+
+import com.soundcloud.twinagle.test.TestMessage
+import com.twitter.finagle.Filter
+import com.twitter.finagle.http.{MediaType, Request}
+import com.twitter.util.{Await, Future, Throw}
+import org.specs2.mutable.Specification
+
+class ServerEndpointBuilderSpec extends Specification {
+
+  "catches exceptions thrown by user code" in {
+    val ex = new Exception("oops")
+
+    def throwingRpc(x: TestMessage): Future[TestMessage] = {
+      throw ex
+    }
+
+    val builder = new ServerEndpointBuilder(_ => Filter.TypeAgnostic.Identity)
+    val (_, svc) = builder.build(
+      throwingRpc,
+      EndpointMetadata("/twirp", "service", "rpc")
+    )
+
+    val request = Request()
+    request.mediaType = MediaType.Json
+    request.contentString = "{}"
+
+    Await.result(svc(request).liftToTry) ==== Throw(ex)
+  }
+}


### PR DESCRIPTION
we want to make sure to catch exceptions thrown by
user implementations of the generated service
interface. We do this by wrapping them in
`Service.rescue()`.

Refactors `ServiceAdapter` to be a `Filter`, since it
really is one.

Fixes #18.