### PR TITLE
prefix private vals in generated code with `_`

### DIFF
--- a/codegen/src/main/scala/com/soundcloud/twinagle/codegen/TwinagleServicePrinter.scala
+++ b/codegen/src/main/scala/com/soundcloud/twinagle/codegen/TwinagleServicePrinter.scala
@@ -79,7 +79,7 @@ final class TwinagleServicePrinter(service: ServiceDescriptor, implicits: Descri
        |                        extension: $EndpointMetadata => $Filter.TypeAgnostic = _ => $Filter.TypeAgnostic.Identity)
        |  extends $serviceName {
        |
-       |  private val builder = new $ClientEndpointBuilder(httpClient, extension)
+       |  private val _builder = new $ClientEndpointBuilder(httpClient, extension)
        |
        |${serviceDescriptor.methods.map(generateJsonClientService).mkString("\n")}
        |${serviceDescriptor.methods.map(generateGenericClientMethod).mkString("\n")}
@@ -97,7 +97,7 @@ final class TwinagleServicePrinter(service: ServiceDescriptor, implicits: Descri
        |                            extension: $EndpointMetadata => $Filter.TypeAgnostic = _ => $Filter.TypeAgnostic.Identity)
        |  extends $serviceName {
        |
-       |  private val builder = new $ClientEndpointBuilder(httpClient, extension)
+       |  private val _builder = new $ClientEndpointBuilder(httpClient, extension)
        |
        |${serviceDescriptor.methods.map(generateProtobufClientService).mkString("\n")}
        |${serviceDescriptor.methods.map(generateGenericClientMethod).mkString("\n")}
@@ -182,9 +182,9 @@ final class TwinagleServicePrinter(service: ServiceDescriptor, implicits: Descri
     val (serviceName, rpcName) = (methodDescriptor.getService.getFullName, getName(methodDescriptor))
     val endpoint = s"""$EndpointMetadata("/twirp", "$serviceName", "$rpcName")"""
     s"""
-       |  private val ${methodName}Service: $Service[$inputType, $outputType] = {
+       |  private val _${methodName}Service: $Service[$inputType, $outputType] = {
        |    implicit val companion = $outputType
-       |    builder.jsonEndpoint($endpoint)
+       |    _builder.jsonEndpoint($endpoint)
        |  }
       """.stripMargin
   }
@@ -196,9 +196,9 @@ final class TwinagleServicePrinter(service: ServiceDescriptor, implicits: Descri
     val (serviceName, rpcName) = (methodDescriptor.getService.getFullName, getName(methodDescriptor))
     val endpoint = s"""$EndpointMetadata("/twirp", "$serviceName", "$rpcName")"""
     s"""
-       |  private val ${methodName}Service: $Service[$inputType, $outputType] = {
+       |  private val _${methodName}Service: $Service[$inputType, $outputType] = {
        |    implicit val companion = $outputType
-       |    builder.protoEndpoint($endpoint)
+       |    _builder.protoEndpoint($endpoint)
        |  }
       """.stripMargin
   }
@@ -208,7 +208,7 @@ final class TwinagleServicePrinter(service: ServiceDescriptor, implicits: Descri
     val outputType = methodOutputType(methodDescriptor)
     val methodName = decapitalizedName(methodDescriptor)
     s"""
-       |  override def $methodName(request: $inputType): $Future[$outputType] = ${methodName}Service(request)
+       |  override def $methodName(request: $inputType): $Future[$outputType] = _${methodName}Service(request)
        """.stripMargin
   }
 


### PR DESCRIPTION
this avoids possible name collisions if a protobuf
file defines two rpcs named `foo` and `fooService`.

It is safe to use `_` as a prefix, since protobuf
rpc names must [start with a letter][1].

[1]: https://developers.google.com/protocol-buffers/docs/reference/proto3-spec#identifiers