### PR TITLE
Adding support for retries on methods marked as idempotent

### DIFF
--- a/codegen/src/main/scala/com/soundcloud/twinagle/codegen/TwinagleServicePrinter.scala
+++ b/codegen/src/main/scala/com/soundcloud/twinagle/codegen/TwinagleServicePrinter.scala
@@ -168,12 +168,16 @@ final class TwinagleServicePrinter(
   private def generateJsonClientService(
       methodDescriptor: MethodDescriptor
   ): String = {
+    val isIdempotent = methodDescriptor.getOptions.getIdempotencyLevel.getNumber match {
+      case 1 | 2 => "true"
+      case _     => "false"
+    }
     val inputType  = methodInputType(methodDescriptor)
     val outputType = methodOutputType(methodDescriptor)
     val methodName = decapitalizedName(methodDescriptor)
     val (serviceName, rpcName) =
       (methodDescriptor.getService.getFullName, getName(methodDescriptor))
-    val endpoint = s"""$EndpointMetadata("/twirp", "$serviceName", "$rpcName")"""
+    val endpoint = s"""$EndpointMetadata("/twirp", "$serviceName", "$rpcName", $isIdempotent)"""
 
     s"""
        |  private val _${methodName}Service: $Service[$inputType, $outputType] = {
@@ -186,12 +190,16 @@ final class TwinagleServicePrinter(
   private def generateProtobufClientService(
       methodDescriptor: MethodDescriptor
   ): String = {
+    val isIdempotent = methodDescriptor.getOptions.getIdempotencyLevel.getNumber match {
+      case 1 | 2 => "true"
+      case _     => "false"
+    }
     val inputType  = methodInputType(methodDescriptor)
     val outputType = methodOutputType(methodDescriptor)
     val methodName = decapitalizedName(methodDescriptor)
     val (serviceName, rpcName) =
       (methodDescriptor.getService.getFullName, getName(methodDescriptor))
-    val endpoint = s"""$EndpointMetadata("/twirp", "$serviceName", "$rpcName")"""
+    val endpoint = s"""$EndpointMetadata("/twirp", "$serviceName", "$rpcName", $isIdempotent)"""
 
     s"""
        |  private val _${methodName}Service: $Service[$inputType, $outputType] = {

--- a/codegen/src/main/scala/com/soundcloud/twinagle/codegen/TwinagleServicePrinter.scala
+++ b/codegen/src/main/scala/com/soundcloud/twinagle/codegen/TwinagleServicePrinter.scala
@@ -24,6 +24,7 @@ final class TwinagleServicePrinter(
   private[this] val EndpointMetadata      = s"$twinagle.EndpointMetadata"
   private[this] val ClientEndpointBuilder = s"$twinagle.ClientEndpointBuilder"
   private[this] val ServerBuilder         = s"$twinagle.ServerBuilder"
+  private[this] val RetryMatcher          = s"Option[PartialFunction[$twinagle.TwinagleException, Boolean]]"
 
   def generateServiceObject(m: ServiceDescriptor): String = {
     val serviceName = getServiceName(m)
@@ -71,7 +72,8 @@ final class TwinagleServicePrinter(
 
     s"""
        |class ${clientName}Json(httpClient: $Service[$Request, $Response],
-       |                        extension: $EndpointMetadata => $Filter.TypeAgnostic = _ => $Filter.TypeAgnostic.Identity)
+       |                        extension: $EndpointMetadata => $Filter.TypeAgnostic = _ => $Filter.TypeAgnostic.Identity,
+       |                        retryMatcher: $RetryMatcher = None)
        |  extends $serviceName {
        |
        |  private val _builder = new $ClientEndpointBuilder(httpClient, extension)
@@ -96,7 +98,8 @@ final class TwinagleServicePrinter(
 
     s"""
        |class ${clientName}Protobuf(httpClient: $Service[$Request, $Response],
-       |                            extension: $EndpointMetadata => $Filter.TypeAgnostic = _ => $Filter.TypeAgnostic.Identity)
+       |                            extension: $EndpointMetadata => $Filter.TypeAgnostic = _ => $Filter.TypeAgnostic.Identity,
+       |                            retryMatcher: $RetryMatcher = None)
        |  extends $serviceName {
        |
        |  private val _builder = new $ClientEndpointBuilder(httpClient, extension)
@@ -179,7 +182,7 @@ final class TwinagleServicePrinter(
     s"""
        |  private val _${methodName}Service: $Service[$inputType, $outputType] = {
        |    implicit val companion = $outputType
-       |    _builder.jsonEndpoint($endpoint)
+       |    _builder.jsonEndpoint($endpoint, retryMatcher)
        |  }
       """.stripMargin
   }
@@ -198,7 +201,7 @@ final class TwinagleServicePrinter(
     s"""
        |  private val _${methodName}Service: $Service[$inputType, $outputType] = {
        |    implicit val companion = $outputType
-       |    _builder.protoEndpoint($endpoint)
+       |    _builder.protoEndpoint($endpoint, retryMatcher)
        |  }
       """.stripMargin
   }

--- a/codegen/src/main/scala/com/soundcloud/twinagle/codegen/TwinagleServicePrinter.scala
+++ b/codegen/src/main/scala/com/soundcloud/twinagle/codegen/TwinagleServicePrinter.scala
@@ -168,13 +168,10 @@ final class TwinagleServicePrinter(
   private def generateJsonClientService(
       methodDescriptor: MethodDescriptor
   ): String = {
-    val isIdempotent = methodDescriptor.getOptions.getIdempotencyLevel.getNumber match {
-      case 1 | 2 => "true"
-      case _     => "false"
-    }
-    val inputType  = methodInputType(methodDescriptor)
-    val outputType = methodOutputType(methodDescriptor)
-    val methodName = decapitalizedName(methodDescriptor)
+    val isIdempotent = isMethodIdempotent(methodDescriptor)
+    val inputType    = methodInputType(methodDescriptor)
+    val outputType   = methodOutputType(methodDescriptor)
+    val methodName   = decapitalizedName(methodDescriptor)
     val (serviceName, rpcName) =
       (methodDescriptor.getService.getFullName, getName(methodDescriptor))
     val endpoint = s"""$EndpointMetadata("/twirp", "$serviceName", "$rpcName", $isIdempotent)"""
@@ -190,13 +187,10 @@ final class TwinagleServicePrinter(
   private def generateProtobufClientService(
       methodDescriptor: MethodDescriptor
   ): String = {
-    val isIdempotent = methodDescriptor.getOptions.getIdempotencyLevel.getNumber match {
-      case 1 | 2 => "true"
-      case _     => "false"
-    }
-    val inputType  = methodInputType(methodDescriptor)
-    val outputType = methodOutputType(methodDescriptor)
-    val methodName = decapitalizedName(methodDescriptor)
+    val isIdempotent = isMethodIdempotent(methodDescriptor)
+    val inputType    = methodInputType(methodDescriptor)
+    val outputType   = methodOutputType(methodDescriptor)
+    val methodName   = decapitalizedName(methodDescriptor)
     val (serviceName, rpcName) =
       (methodDescriptor.getService.getFullName, getName(methodDescriptor))
     val endpoint = s"""$EndpointMetadata("/twirp", "$serviceName", "$rpcName", $isIdempotent)"""
@@ -237,6 +231,13 @@ final class TwinagleServicePrinter(
          |  */""".stripMargin
     } else {
       ""
+    }
+  }
+
+  private def isMethodIdempotent(methodDescriptor: MethodDescriptor) = {
+    methodDescriptor.getOptions.getIdempotencyLevel.getNumber match {
+      case 1 | 2 => "true"
+      case _     => "false"
     }
   }
 }

--- a/codegen/src/sbt-test/generator/e2e/src/main/protobuf/haberdasher.proto
+++ b/codegen/src/sbt-test/generator/e2e/src/main/protobuf/haberdasher.proto
@@ -28,5 +28,7 @@ message Size {
 // A Haberdasher makes hats for clients.
 service Haberdasher {
   // MakeHat produces a hat of mysterious, randomly-selected color!
-  rpc MakeHat(Size) returns (Hat);
+  rpc MakeHat(Size) returns (Hat) {
+    option idempotency_level = IDEMPOTENT;
+  }
 }

--- a/codegen/src/sbt-test/generator/e2e/src/test/scala/twitch/twirp/example/haberdasher/haberdasher/HaberdasherSpec.scala
+++ b/codegen/src/sbt-test/generator/e2e/src/test/scala/twitch/twirp/example/haberdasher/haberdasher/HaberdasherSpec.scala
@@ -18,19 +18,40 @@ class HaberdasherSpec extends Specification {
           )
         )
       } else {
-        Future.exception(TwinagleException(ErrorCode.InvalidArgument, "size must be positive"))
+        Future.exception(
+          TwinagleException(ErrorCode.InvalidArgument, "size must be positive"))
       }
   }
 
+  val faultySvc = new HaberdasherService {
+    var shouldFail = true
+    override def makeHat(size: Size): Future[Hat] =
+      if (shouldFail) {
+        shouldFail = false
+        Future.exception(
+          TwinagleException(ErrorCode.InvalidArgument,
+                            "failing because I'm flaky!"))
+      } else if (size.inches >= 0) {
+        Future.value(
+          Hat(
+            size = size.inches,
+            color = "brown",
+            name = "bowler"
+          )
+        )
+      } else {
+        Future.exception(
+          TwinagleException(ErrorCode.InvalidArgument, "size must be positive"))
+      }
+  }
 
-  val httpService: Service[http.Request, http.Response] = HaberdasherService.server(svc)
-
+  val httpService: Service[http.Request, http.Response] =
+    HaberdasherService.server(svc)
 
   "ClientJson" >> {
 
-    val client = new HaberdasherClientJson(httpService)
-
     "make a valid HTTP request" in {
+      val client = new HaberdasherClientJson(httpService)
       val hat = Await.result(client.makeHat(Size(12)))
 
       hat.color ==== "brown"
@@ -38,20 +59,29 @@ class HaberdasherSpec extends Specification {
     }
 
     "produces TwinagleExceptions for error responses" in {
-      val Throw(ex: TwinagleException) = Await.result(client.makeHat(Size(-1)).liftToTry)
+      val client = new HaberdasherClientJson(httpService)
+      val Throw(ex: TwinagleException) =
+        Await.result(client.makeHat(Size(-1)).liftToTry)
 
       ex.code ==== ErrorCode.InvalidArgument
     }
 
-  }
+    "retries idempotent methods" in {
+      val faultyHttpService: Service[http.Request, http.Response] =
+        HaberdasherService.server(faultySvc)
 
+      val client = new HaberdasherClientJson(faultyHttpService)
+
+      val hat = Await.result(client.makeHat(Size(12)))
+      hat.color ==== "brown"
+      hat.size ==== 12
+    }
+  }
 
   "ClientProtobuf" >> {
 
-    val client = new HaberdasherClientProtobuf(httpService)
-
     "make a valid HTTP request" in {
-
+      val client = new HaberdasherClientProtobuf(httpService)
       val hat = Await.result(client.makeHat(Size(12)))
 
       hat.color ==== "brown"
@@ -59,9 +89,23 @@ class HaberdasherSpec extends Specification {
     }
 
     "produces TwinagleExceptions for error responses" in {
-      val Throw(ex: TwinagleException) = Await.result(client.makeHat(Size(-1)).liftToTry)
+      val client = new HaberdasherClientProtobuf(httpService)
+      val Throw(ex: TwinagleException) =
+        Await.result(client.makeHat(Size(-1)).liftToTry)
 
       ex.code ==== ErrorCode.InvalidArgument
+    }
+
+    "retries idempotent methods" in {
+
+      val faultyHttpService: Service[http.Request, http.Response] =
+        HaberdasherService.server(faultySvc)
+
+      val client = new HaberdasherClientProtobuf(faultyHttpService)
+
+      val hat = Await.result(client.makeHat(Size(12)))
+      hat.color ==== "brown"
+      hat.size ==== 12
     }
   }
 }

--- a/codegen/src/sbt-test/generator/e2e/src/test/scala/twitch/twirp/example/haberdasher/haberdasher/HaberdasherSpec.scala
+++ b/codegen/src/sbt-test/generator/e2e/src/test/scala/twitch/twirp/example/haberdasher/haberdasher/HaberdasherSpec.scala
@@ -7,7 +7,7 @@ import org.specs2.mutable.Specification
 
 class HaberdasherSpec extends Specification {
 
-  def makeHat(size: Size): Future[Hat] = {
+  def haderdash(size: Size): Future[Hat] = {
     if (size.inches >= 0) {
       Future.value(
         Hat(
@@ -23,7 +23,7 @@ class HaberdasherSpec extends Specification {
   }
 
   val svc = new HaberdasherService {
-    override def makeHat(size: Size): Future[Hat] = makeHat(size)
+    override def makeHat(size: Size): Future[Hat] = haderdash(size)
   }
 
   val flakySvc = new HaberdasherService {
@@ -34,7 +34,7 @@ class HaberdasherSpec extends Specification {
         Future.exception(
           TwinagleException(ErrorCode.Unknown, "failing because I'm flaky!"))
       } else {
-        makeHat(size)
+        haderdash(size)
       }
     }
   }

--- a/codegen/src/sbt-test/generator/e2e/src/test/scala/twitch/twirp/example/haberdasher/haberdasher/HaberdasherSpec.scala
+++ b/codegen/src/sbt-test/generator/e2e/src/test/scala/twitch/twirp/example/haberdasher/haberdasher/HaberdasherSpec.scala
@@ -42,6 +42,10 @@ class HaberdasherSpec extends Specification {
   val httpService: Service[http.Request, http.Response] =
     HaberdasherService.server(svc)
 
+  val retry: Option[PartialFunction[TwinagleException, Boolean]] = Some({
+    case _ => true
+  })
+
   "ClientJson" >> {
 
     "make a valid HTTP request" in {
@@ -64,7 +68,8 @@ class HaberdasherSpec extends Specification {
       val faultyHttpService: Service[http.Request, http.Response] =
         HaberdasherService.server(flakySvc)
 
-      val client = new HaberdasherClientJson(faultyHttpService)
+      val client =
+        new HaberdasherClientJson(faultyHttpService, retryMatcher = retry)
 
       val hat = Await.result(client.makeHat(Size(12)))
       hat.color ==== "brown"
@@ -95,7 +100,8 @@ class HaberdasherSpec extends Specification {
       val faultyHttpService: Service[http.Request, http.Response] =
         HaberdasherService.server(flakySvc)
 
-      val client = new HaberdasherClientProtobuf(faultyHttpService)
+      val client =
+        new HaberdasherClientProtobuf(faultyHttpService, retryMatcher = retry)
 
       val hat = Await.result(client.makeHat(Size(12)))
       hat.color ==== "brown"

--- a/runtime/src/main/scala/com/soundcloud/twinagle/ClientEndpointBuilder.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/ClientEndpointBuilder.scala
@@ -51,11 +51,7 @@ class ClientEndpointBuilder(
   }
 
   private def buildRetryFilter[Req, Resp](isIdempotent: Boolean) = { // TODO: Are these values reasonable? How configurable should they be?
-    val retryPolicy = if (isIdempotent) {
-      shouldRetry[Req, Resp]
-    } else {
-      defaultRetry
-    }
+    val retryPolicy = if (isIdempotent) shouldRetry[Req, Resp] else defaultRetry
     new RetryFilter[Req, Resp](
       RetryPolicy.tries(3, retryPolicy),
       HighResTimer.Default,

--- a/runtime/src/main/scala/com/soundcloud/twinagle/ClientEndpointBuilder.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/ClientEndpointBuilder.scala
@@ -1,8 +1,16 @@
 package com.soundcloud.twinagle
 
+import com.twitter.conversions.DurationOps._
 import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finagle.param.HighResTimer
+import com.twitter.finagle.service.RetryPolicy.RetryableWriteException
+import com.twitter.finagle.service._
+import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.finagle.{Filter, Service}
+import com.twitter.util.{Throw, Try}
 import scalapb.{GeneratedMessage, GeneratedMessageCompanion, Message}
+
+import scala.util.control.NonFatal
 
 class ClientEndpointBuilder(
     httpClient: Service[Request, Response],
@@ -15,7 +23,11 @@ class ClientEndpointBuilder(
   ](
       endpointMetadata: EndpointMetadata
   ): Service[Req, Resp] = {
+
+    val retryFilter: Filter[Req, Resp, Req, Resp] = buildRetryFilter(endpointMetadata.isIdempotent)
+
     extension(endpointMetadata).toFilter andThen
+      retryFilter andThen
       new TracingFilter[Req, Resp](endpointMetadata) andThen
       new JsonClientFilter[Req, Resp](endpointMetadata.path) andThen
       new TwirpHttpClient andThen
@@ -28,11 +40,40 @@ class ClientEndpointBuilder(
   ](
       endpointMetadata: EndpointMetadata
   ): Service[Req, Resp] = {
+    val retryFilter: Filter[Req, Resp, Req, Resp] = buildRetryFilter(endpointMetadata.isIdempotent)
     extension(endpointMetadata).toFilter andThen
+      retryFilter andThen
       new TracingFilter[Req, Resp](endpointMetadata) andThen
       new ProtobufClientFilter[Req, Resp](endpointMetadata.path) andThen
       new TwirpHttpClient andThen
       httpClient
 
   }
+
+  private def buildRetryFilter[Req, Resp](isIdempotent: Boolean) = { // TODO: Are these values reasonable? How configurable should they be?
+    val retryPolicy = if (isIdempotent) {
+      shouldRetry[Req, Resp]
+    } else {
+      defaultRetry
+    }
+    new RetryFilter[Req, Resp](
+      RetryPolicy.tries(3, retryPolicy),
+      HighResTimer.Default,
+      new NullStatsReceiver,
+      RetryBudget(60.seconds, 10, 0.2f)
+    )
+  }
+
+  // Retries all NonFatal exceptions
+  // TODO: Make a more informed decision about retrying
+  private def shouldRetry[Req, Resp]: PartialFunction[(Req, Try[Resp]), Boolean] = {
+    case (_, Throw(t)) => NonFatal(t)
+    case _             => false
+  }
+
+  private def defaultRetry[Req, Resp]: PartialFunction[(Req, Try[Resp]), Boolean] = {
+    case (_, Throw(RetryableWriteException(_))) => true
+    case _                                      => false
+  }
+
 }

--- a/runtime/src/main/scala/com/soundcloud/twinagle/ClientEndpointBuilder.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/ClientEndpointBuilder.scala
@@ -7,10 +7,8 @@ import com.twitter.finagle.service.RetryPolicy.RetryableWriteException
 import com.twitter.finagle.service._
 import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.finagle.{Filter, Service}
-import com.twitter.util.{Throw, Try}
+import com.twitter.util.{Return, Throw, Try}
 import scalapb.{GeneratedMessage, GeneratedMessageCompanion, Message}
-
-import scala.util.control.NonFatal
 
 class ClientEndpointBuilder(
     httpClient: Service[Request, Response],
@@ -21,16 +19,17 @@ class ClientEndpointBuilder(
       Req <: GeneratedMessage,
       Resp <: GeneratedMessage with Message[Resp]: GeneratedMessageCompanion
   ](
-      endpointMetadata: EndpointMetadata
+      endpointMetadata: EndpointMetadata,
+      retryMatcher: Option[PartialFunction[TwinagleException, Boolean]]
   ): Service[Req, Resp] = {
 
-    val retryFilter: Filter[Req, Resp, Req, Resp] = buildRetryFilter(endpointMetadata.isIdempotent)
+    val retryFilter: RetryFilter[Request, Response] = buildHttpRetryFilter(endpointMetadata.isIdempotent, retryMatcher)
 
     extension(endpointMetadata).toFilter andThen
-      retryFilter andThen
       new TracingFilter[Req, Resp](endpointMetadata) andThen
       new JsonClientFilter[Req, Resp](endpointMetadata.path) andThen
       new TwirpHttpClient andThen
+      retryFilter andThen
       httpClient
   }
 
@@ -38,38 +37,42 @@ class ClientEndpointBuilder(
       Req <: GeneratedMessage,
       Resp <: GeneratedMessage with Message[Resp]: GeneratedMessageCompanion
   ](
-      endpointMetadata: EndpointMetadata
+      endpointMetadata: EndpointMetadata,
+      retryMatcher: Option[PartialFunction[TwinagleException, Boolean]]
   ): Service[Req, Resp] = {
-    val retryFilter: Filter[Req, Resp, Req, Resp] = buildRetryFilter(endpointMetadata.isIdempotent)
+    val retryFilter: RetryFilter[Request, Response] = buildHttpRetryFilter(endpointMetadata.isIdempotent, retryMatcher)
+
     extension(endpointMetadata).toFilter andThen
-      retryFilter andThen
       new TracingFilter[Req, Resp](endpointMetadata) andThen
       new ProtobufClientFilter[Req, Resp](endpointMetadata.path) andThen
       new TwirpHttpClient andThen
+      retryFilter andThen
       httpClient
 
   }
 
-  private def buildRetryFilter[Req, Resp](isIdempotent: Boolean) = { // TODO: Are these values reasonable? How configurable should they be?
-    val retryPolicy = if (isIdempotent) shouldRetry[Req, Resp] else defaultRetry
-    new RetryFilter[Req, Resp](
-      RetryPolicy.tries(3, retryPolicy),
+  private def buildHttpRetryFilter(isIdempotent: Boolean,
+                                   retryMatcher: Option[PartialFunction[TwinagleException, Boolean]]) = {
+    new RetryFilter[Request, Response](
+      RetryPolicy.tries(3, {
+        case (req, resp) if isIdempotent => httpRetryPolicy(retryMatcher)((req, resp))
+      }),
       HighResTimer.Default,
       new NullStatsReceiver,
       RetryBudget(60.seconds, 10, 0.2f)
     )
   }
 
-  // Retries all NonFatal exceptions
-  // TODO: Make a more informed decision about retrying
-  private def shouldRetry[Req, Resp]: PartialFunction[(Req, Try[Resp]), Boolean] = {
-    case (_, Throw(t)) => NonFatal(t)
-    case _             => false
-  }
-
-  private def defaultRetry[Req, Resp]: PartialFunction[(Req, Try[Resp]), Boolean] = {
-    case (_, Throw(RetryableWriteException(_))) => true
-    case _                                      => false
+  private def httpRetryPolicy(
+      retryMatcher: Option[PartialFunction[TwinagleException, Boolean]]
+  ): PartialFunction[(Request, Try[Response]), Boolean] = {
+    case (_, response) =>
+      (response, retryMatcher) match {
+        case (Return(r), Some(f)) =>
+          f(TwirpHttpClient.errorFromResponse(r))
+        case (Throw(RetryableWriteException(_)), _) => true // No bytes written to the wire, very conservative retry
+        case _                                      => false
+      }
   }
 
 }

--- a/runtime/src/main/scala/com/soundcloud/twinagle/EndpointMetadata.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/EndpointMetadata.scala
@@ -7,7 +7,7 @@ package com.soundcloud.twinagle
   * @param service absolute name of the Twirp service.
   * @param rpc     name of the RPC endpoint within the Twirp service.
   */
-case class EndpointMetadata(prefix: String, service: String, rpc: String) {
+case class EndpointMetadata(prefix: String, service: String, rpc: String, isIdempotent: Boolean = false) {
   require(prefix.startsWith("/"))
   require(!prefix.endsWith("/"))
 

--- a/runtime/src/main/scala/com/soundcloud/twinagle/JsonClientFilter.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/JsonClientFilter.scala
@@ -18,6 +18,7 @@ private[twinagle] class JsonClientFilter[
       service: Service[Request, Response]
   ): Future[Rep] = {
     val httpRequest = serializeRequest(path, request)
+
     service(httpRequest).map(deserializeResponse)
   }
 

--- a/runtime/src/main/scala/com/soundcloud/twinagle/JsonClientFilter.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/JsonClientFilter.scala
@@ -18,7 +18,6 @@ private[twinagle] class JsonClientFilter[
       service: Service[Request, Response]
   ): Future[Rep] = {
     val httpRequest = serializeRequest(path, request)
-
     service(httpRequest).map(deserializeResponse)
   }
 

--- a/runtime/src/main/scala/com/soundcloud/twinagle/TwirpHttpClient.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/TwirpHttpClient.scala
@@ -15,10 +15,13 @@ private[twinagle] class TwirpHttpClient extends SimpleFilter[Request, Response] 
     service(request).flatMap { response =>
       response.status match {
         case Status.Ok => Future.value(response)
-        case _         => Future.exception(errorFromResponse(response))
+        case _         => Future.exception(TwirpHttpClient.errorFromResponse(response))
       }
     }
   }
+}
+
+object TwirpHttpClient {
 
   // Error handling ported from the Go implementation of Twirp:
   // https://github.com/twitchtv/twirp/blob/3b7987b1a81780060352721385655fdcbf9c12da/protoc-gen-twirp/generator.go#L488-L528
@@ -27,7 +30,7 @@ private[twinagle] class TwirpHttpClient extends SimpleFilter[Request, Response] 
   // If the response has a valid serialized Twirp error, then it's returned.
   // If not, the response status code is used to generate a similar twirp
   // error. See twirpErrorFromIntermediary for more info on intermediary errors.
-  private def errorFromResponse(httpResponse: Response): TwinagleException =
+  def errorFromResponse(httpResponse: Response): TwinagleException =
     if (isRedirect(httpResponse.status)) {
       // Unexpected redirect: it must be an error from an intermediary.
       // Twirp clients don't follow redirects automatically, Twirp only handles

--- a/runtime/src/test/scala/com/soundcloud/twinagle/ServerSpec.scala
+++ b/runtime/src/test/scala/com/soundcloud/twinagle/ServerSpec.scala
@@ -13,7 +13,7 @@ class ServerSpec extends Specification with Mockito {
   trait Context extends Scope {
     val rpc = mock[TestMessage => Future[TestMessage]]
     val server = ServerBuilder(_ => Filter.TypeAgnostic.Identity)
-      .register(EndpointMetadata("/twirp", "svc", "rpc"), rpc)
+      .register(EndpointMetadata("/twirp", "svc", "rpc", false), rpc)
       .build
   }
 

--- a/runtime/src/test/scala/com/soundcloud/twinagle/TracingFilterSpec.scala
+++ b/runtime/src/test/scala/com/soundcloud/twinagle/TracingFilterSpec.scala
@@ -26,7 +26,7 @@ class TracingFilterSpec extends Specification {
   "adds annotations" >> {
     "successful request" in new Context {
       Trace.letTracer(tracer) {
-        val svc = new TracingFilter(EndpointMetadata("/twirp", "svc", "rpc")) andThen
+        val svc = new TracingFilter(EndpointMetadata("/twirp", "svc", "rpc", false)) andThen
           Service.const(Future.value(response))
         Await.result(svc(request))
       }
@@ -43,7 +43,7 @@ class TracingFilterSpec extends Specification {
     "twinagle errors" in new Context {
       val exception = TwinagleException(ErrorCode.NotFound, "foo not found")
       Trace.letTracer(tracer) {
-        val svc = new TracingFilter(EndpointMetadata("/twirp", "svc", "rpc")) andThen
+        val svc = new TracingFilter(EndpointMetadata("/twirp", "svc", "rpc", false)) andThen
           Service.const(Future.exception(exception))
         Await.result(svc(request).liftToTry)
       }
@@ -62,7 +62,7 @@ class TracingFilterSpec extends Specification {
     "other errors" in new Context {
       val exception = new RuntimeException("boom")
       Trace.letTracer(tracer) {
-        val svc = new TracingFilter(EndpointMetadata("/twirp", "svc", "rpc")) andThen
+        val svc = new TracingFilter(EndpointMetadata("/twirp", "svc", "rpc", false)) andThen
           Service.const(Future.exception(exception))
         Await.result(svc(request).liftToTry)
       }


### PR DESCRIPTION
Addresses #9 

Here's a PR for retries based on the Idempotent annotation. A few questions outstanding:

Are these retry values reasonable? 
How configurable should they be?
What kinds of errors should we actually try? Should we be operating on a subset of the `TwinagleExceptions`?

Another recommendation is that we can change the HTTP Verb based on the idempotency annotation (no side effects -> GET, idempotent -> PUT), but that seems unnecessary, or at least out of scope