### PR TITLE
Support for clients sending custom HTTP headers and servers reading them

### DIFF
--- a/runtime/src/main/scala/com/soundcloud/twinagle/TwirpEndpointFilter.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/TwirpEndpointFilter.scala
@@ -1,7 +1,8 @@
 package com.soundcloud.twinagle
 
+import com.soundcloud.twinagle.session.SessionCache
 import com.twitter.finagle.{Filter, Service}
-import com.twitter.finagle.http.{MediaType, Request, Response, Status}
+import com.twitter.finagle.http._
 import com.twitter.io.Buf
 import com.twitter.util.Future
 import scalapb.json4s.JsonFormat
@@ -23,32 +24,36 @@ private[twinagle] class TwirpEndpointFilter[
   override def apply(
       request: Request,
       service: Service[Req, Rep]
-  ): Future[Response] = request.mediaType match {
-    case Some(MediaType.Json) =>
-      val input = JsonFormat.fromJsonString[Req](request.contentString)
-      service(input).map { r =>
-        val response = Response(Status.Ok)
-        response.contentType = MediaType.Json
-        response.contentString = JsonFormat.toJsonString(r)
-        response
+  ): Future[Response] = {
+    SessionCache.context.let(SessionCache.customHeadersKey, request.headerMap) {
+      request.mediaType match {
+        case Some(MediaType.Json) =>
+          val input = JsonFormat.fromJsonString[Req](request.contentString)
+          service(input).map { r =>
+            val response = Response(Status.Ok)
+            response.contentType = MediaType.Json
+            response.contentString = JsonFormat.toJsonString(r)
+            response
+          }
+        case Some("application/protobuf") =>
+          val input = implicitly[GeneratedMessageCompanion[Req]]
+            .parseFrom(toBytes(request.content))
+          service(input).map { r =>
+            val response = Response(Status.Ok)
+            response.contentType = "application/protobuf"
+            response.content = Buf.ByteArray.Owned(r.toByteArray)
+            response
+          }
+        case _ =>
+          val contentType = request.contentType.getOrElse("")
+          Future.exception(
+            TwinagleException(
+              ErrorCode.BadRoute,
+              s"unexpected Content-Type: '$contentType'"
+            )
+          )
       }
-    case Some("application/protobuf") =>
-      val input = implicitly[GeneratedMessageCompanion[Req]]
-        .parseFrom(toBytes(request.content))
-      service(input).map { r =>
-        val response = Response(Status.Ok)
-        response.contentType = "application/protobuf"
-        response.content = Buf.ByteArray.Owned(r.toByteArray)
-        response
-      }
-    case _ =>
-      val contentType = request.contentType.getOrElse("")
-      Future.exception(
-        TwinagleException(
-          ErrorCode.BadRoute,
-          s"unexpected Content-Type: '$contentType'"
-        )
-      )
+    }
   }
 
   private def toBytes(buf: Buf): Array[Byte] = Buf.ByteArray.Owned.extract(buf)

--- a/runtime/src/main/scala/com/soundcloud/twinagle/TwirpHttpClient.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/TwirpHttpClient.scala
@@ -1,5 +1,6 @@
 package com.soundcloud.twinagle
 
+import com.soundcloud.twinagle.session.SessionCache
 import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.finagle.{Service, SimpleFilter}
 import com.twitter.util.Future
@@ -12,6 +13,8 @@ private[twinagle] class TwirpHttpClient extends SimpleFilter[Request, Response] 
       request: Request,
       service: Service[Request, Response]
   ): Future[Response] = {
+    val headersFromContext = SessionCache.context.get(SessionCache.customHeadersKey)
+    headersFromContext.foreach(request.headerMap ++= _)
     service(request).flatMap { response =>
       response.status match {
         case Status.Ok => Future.value(response)

--- a/runtime/src/main/scala/com/soundcloud/twinagle/session/SessionCache.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/session/SessionCache.scala
@@ -1,0 +1,9 @@
+package com.soundcloud.twinagle.session
+
+import com.twitter.finagle.context.{Contexts, LocalContext}
+import com.twitter.finagle.http.HeaderMap
+
+object SessionCache {
+  final val context: LocalContext                    = Contexts.local
+  final val customHeadersKey: context.Key[HeaderMap] = context.newKey[HeaderMap]()
+}


### PR DESCRIPTION
This is basic support so that Clients can send Custom HTTP headers and servers can read them.

See #32 for context