### PR TITLE
[BREAKING CHANGE] don't include proto filename in packages

### DIFF
--- a/codegen/src/main/scala/com/soundcloud/twinagle/codegen/ServerClientCodeGenerator.scala
+++ b/codegen/src/main/scala/com/soundcloud/twinagle/codegen/ServerClientCodeGenerator.scala
@@ -11,8 +11,6 @@ import scalapb.options.compiler.Scalapb
 import scala.collection.JavaConverters._
 
 object ServerClientCodeGenerator extends protocbridge.ProtocCodeGenerator {
-  val params = scalapb.compiler.GeneratorParams()
-
   // This would make sbt-protoc append the following artifacts to the user's
   // project.  If you have a runtime library this is the place to specify it.
   override def suggestedDependencies: Seq[protocbridge.Artifact] = Seq(

--- a/codegen/src/main/scala/com/soundcloud/twinagle/codegen/Twinagle.scala
+++ b/codegen/src/main/scala/com/soundcloud/twinagle/codegen/Twinagle.scala
@@ -7,14 +7,23 @@ import sbt.plugins.JvmPlugin
 import sbtprotoc.ProtocPlugin.autoImport.PB
 
 object Twinagle extends AutoPlugin {
+  val scalapbCodeGeneratorOptions = settingKey[Set[scalapb.GeneratorOption]]("Settings for scalapb code generation")
+
   override def requires: Plugins = sbtprotoc.ProtocPlugin && JvmPlugin
 
   override def trigger: PluginTrigger = NoTrigger
 
   override def projectSettings: Seq[Def.Setting[_]] = List(
+    scalapbCodeGeneratorOptions := Set(
+      scalapb.GeneratorOption.FlatPackage // don't include proto filename in scala package name
+    ),
     Compile / PB.targets := Seq(
-      Target(scalapb.gen(grpc = false), (sourceManaged in Compile).value),
-      Target(JvmGenerator("scala-twinagle", ServerClientCodeGenerator), (sourceManaged in Compile).value)
+      Target(scalapb.gen(scalapbCodeGeneratorOptions.value), (sourceManaged in Compile).value),
+      Target(
+        JvmGenerator("scala-twinagle", ServerClientCodeGenerator),
+        (sourceManaged in Compile).value,
+        scalapb.gen(scalapbCodeGeneratorOptions.value)._2
+      )
     ),
     libraryDependencies ++= Seq(
       "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion % "protobuf"

--- a/codegen/src/main/scala/com/soundcloud/twinagle/codegen/Twinagle.scala
+++ b/codegen/src/main/scala/com/soundcloud/twinagle/codegen/Twinagle.scala
@@ -18,7 +18,10 @@ object Twinagle extends AutoPlugin {
       scalapb.GeneratorOption.FlatPackage // don't include proto filename in scala package name
     ),
     Compile / PB.targets := Seq(
-      Target(scalapb.gen(scalapbCodeGeneratorOptions.value), (sourceManaged in Compile).value),
+      Target(
+        scalapb.gen(scalapbCodeGeneratorOptions.value - scalapb.GeneratorOption.Grpc),
+        (sourceManaged in Compile).value
+      ),
       Target(
         JvmGenerator("scala-twinagle", ServerClientCodeGenerator),
         (sourceManaged in Compile).value,

--- a/codegen/src/sbt-test/generator/e2e/src/test/scala/proto/test/UnknownFieldsSpec.scala
+++ b/codegen/src/sbt-test/generator/e2e/src/test/scala/proto/test/UnknownFieldsSpec.scala
@@ -1,4 +1,4 @@
-package proto.test.unknown_fields
+package proto.test
 
 import org.specs2.mutable.Specification
 

--- a/codegen/src/sbt-test/generator/e2e/src/test/scala/twitch/twirp/example/haberdasher/HaberdasherSpec.scala
+++ b/codegen/src/sbt-test/generator/e2e/src/test/scala/twitch/twirp/example/haberdasher/HaberdasherSpec.scala
@@ -1,4 +1,4 @@
-package twitch.twirp.example.haberdasher.haberdasher
+package twitch.twirp.example.haberdasher
 
 import com.soundcloud.twinagle.{ErrorCode, TwinagleException}
 import com.twitter.finagle.{Service, http}


### PR DESCRIPTION
introduce an option for the Twinagle plugin to control
the code-gen options used by ScalaPB.

By default, we include the `flat_package` option, so
that we don't inlcude the protobuf filename in the
scala package of generated code.