### PR TITLE
Build for scala 2.13 + fix cross-build settings

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,6 +13,6 @@ test_task:
     folder: $HOME/.sbt/boot
     fingerprint_script: cat project/build.properties
     populate_script: sbt update
-  test_script: sbt test scripted
+  test_script: sbt +test scripted
   scalafmt_script: sbt scalafmtCheckAll
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,8 @@
 lazy val scala212 = "2.12.10"
-lazy val scala211 = "2.11.12"
-
-ThisBuild / scalaVersion := scala212
+lazy val scala213 = "2.13.1"
 
 lazy val commonSettings = List(
+  scalaVersion := scala212,
   scalacOptions ++= Seq(
     "-encoding", "utf8",
     "-deprecation",
@@ -14,14 +13,12 @@ lazy val commonSettings = List(
   Compile / console / scalacOptions --= Seq("-deprecation", "-Xfatal-warnings", "-Xlint")
 )
 
-// Cross-compilation does not work for 2.11, haven't found the right combination of (sbt-protoc and sbt) versions
 lazy val codegen = (project in file("codegen"))
   .enablePlugins(SbtPlugin, BuildInfoPlugin)
   .settings(
     commonSettings,
     name := "twinagle-scalapb-plugin",
 
-    crossSbtVersions := List(sbtVersion.value, "1.2.7"),
     addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.27"),
     libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % scalapb.compiler.Version.scalapbVersion,
 
@@ -37,7 +34,7 @@ lazy val codegen = (project in file("codegen"))
 lazy val runtime = (project in file("runtime")).settings(
   commonSettings,
   name := "twinagle-runtime",
-  crossScalaVersions := Seq(scala211, scalaVersion.value),
+  crossScalaVersions := Seq(scala212, scala213),
   libraryDependencies ++= Seq(
     "com.twitter" %% "finagle-http" % "20.1.0",
     "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion,
@@ -53,7 +50,6 @@ lazy val root = (project in file("."))
   .aggregate(runtime, codegen)
   .settings(
     name := "twinagle-root",
-    crossScalaVersions := Nil,
     resolvers += Resolver.typesafeIvyRepo("releases"),
     skip in publish := true
   )

--- a/runtime/src/test/scala/com/soundcloud/twinagle/TwirpEndpointFilterSpec.scala
+++ b/runtime/src/test/scala/com/soundcloud/twinagle/TwirpEndpointFilterSpec.scala
@@ -64,16 +64,22 @@ class TwirpEndpointFilterSpec extends Specification {
       request.contentType = "application/xml; charset=UTF-8"
       request.contentString = "{}"
 
-      val Throw(ex: TwinagleException) = Await.result(svc(request).liftToTry)
-      ex.code ==== ErrorCode.BadRoute
+      Await.result(svc(request).liftToTry) match {
+        case Throw(ex: TwinagleException) =>
+          ex.code ==== ErrorCode.BadRoute
+        case _ => ko
+      }
     }
 
     "unspecified" in new Context {
       val request = Request()
       request.contentString = "{}"
 
-      val Throw(ex: TwinagleException) = Await.result(svc(request).liftToTry)
-      ex.code ==== ErrorCode.BadRoute
+      Await.result(svc(request).liftToTry) match {
+        case Throw(ex: TwinagleException) =>
+          ex.code ==== ErrorCode.BadRoute
+        case _ => ko
+      }
     }
   }
 }

--- a/runtime/src/test/scala/com/soundcloud/twinagle/TwirpHttpClientSpec.scala
+++ b/runtime/src/test/scala/com/soundcloud/twinagle/TwirpHttpClientSpec.scala
@@ -20,14 +20,16 @@ class TwirpHttpClientSpec extends Specification {
     "redirect" in {
       val response = Response(Status.MovedPermanently)
       val svc      = Service.const(Future.value(response))
-      val Throw(ex: TwinagleException) =
-        Await.result(client(request, svc).liftToTry)
-      ex.code ==== ErrorCode.Internal
-      ex.meta should haveKeys(
-        "location",
-        "http_error_code_from_intermediary",
-        "status_code"
-      )
+      Await.result(client(request, svc).liftToTry) match {
+        case Throw(ex: TwinagleException) =>
+          ex.code ==== ErrorCode.Internal
+          ex.meta should haveKeys(
+            "location",
+            "http_error_code_from_intermediary",
+            "status_code"
+          )
+        case _ => ko
+      }
     }
 
     Fragments.foreach(
@@ -49,14 +51,16 @@ class TwirpHttpClientSpec extends Specification {
         s"HTTP ${status.code} produces $errorCode" ! {
           val response = Response(status)
           val svc      = Service.const(Future.value(response))
-          val Throw(ex: TwinagleException) =
-            Await.result(client(request, svc).liftToTry)
-          ex.code ==== errorCode
-          ex.meta should haveKeys(
-            "body",
-            "http_error_code_from_intermediary",
-            "status_code"
-          )
+          Await.result(client(request, svc).liftToTry) match {
+            case Throw(ex: TwinagleException) =>
+              ex.code ==== errorCode
+              ex.meta should haveKeys(
+                "body",
+                "http_error_code_from_intermediary",
+                "status_code"
+              )
+            case _ => ko
+          }
         }
     }
   }


### PR DESCRIPTION
- Cross-compile for scala 2.13 (in addition to 2.12)
- Remove scala 2.11 support (no longer supported by ScalaPB)
- Test against all scala versions on CI
- Remove useless sbt cross build (sbt 1.2.x is the same as 1.3.x)
- Fix non-exhaustive match error in specs (new since 2.13)

