### PR TITLE
Do not use caches on CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,14 +5,6 @@ container:
   memory: 2
 
 test_task:
-  ivy_cache:
-    folder: $HOME/.ivy2/cache
-    fingerprint_script: find . -name '*.sbt' | xargs cat
-    populate_script: sbt update
-  sbt_cache:
-    folder: $HOME/.sbt/boot
-    fingerprint_script: cat project/build.properties
-    populate_script: sbt update
   test_script: sbt test scripted
   scalafmt_script: sbt scalafmtCheckAll
 


### PR DESCRIPTION
We're not caching everything anyway (coursier is missing) and these
caches might be slower than just downloading everything directly from
maven.org

Let's compare build times and merge this if it gets better.