### PR TITLE
configure a separate build for pull requests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,15 @@
+on: pull_request
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Run tests
+      run: sbt +test scripted

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -1,4 +1,9 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  tags:
+    # run for all tags
 
 jobs:
   build:
@@ -16,7 +21,6 @@ jobs:
       run: sbt +test scripted
     - uses: olafurpg/setup-gpg@v2
     - name: Release
-      if: github.repository.fork == false
       env:
         CI_SNAPSHOT_RELEASE: "+publishSigned"
         PGP_PASSPHRASE: ${{ secrets.PGP_PASSWORD }}

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -2,8 +2,6 @@ on:
   push:
     branches:
       - master
-  tags:
-    # run for all tags
 
 jobs:
   build:

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+    - master
 
 jobs:
   build:


### PR DESCRIPTION
the previous setup would not ignore the `Release` step for pull requests (e.g. the scala-steward ones), causing them to fail.
To work around this, we define an entirely separate build instead.