### PR TITLE
 allow multiple proto services per Twinagle Server

### DIFF
--- a/codegen/src/main/scala/com/soundcloud/twinagle/codegen/TwinagleServicePrinter.scala
+++ b/codegen/src/main/scala/com/soundcloud/twinagle/codegen/TwinagleServicePrinter.scala
@@ -38,13 +38,17 @@ final class TwinagleServicePrinter(
   }
 
   def registerEndpoint(md: MethodDescriptor): String = {
-    val prefix           = "/twirp"
-    val svc              = md.getService.getFullName
-    val methodName       = getName(md)
-    val endpointMetadata = s"""$EndpointMetadata("$prefix", "$svc", "$methodName")"""
-    val rpc              = s"""service.${decapitalizedName(md)}"""
+    val meta = endpointMetadata(md)
+    val rpc  = s"""service.${decapitalizedName(md)}"""
 
-    s"""      .register($endpointMetadata, $rpc _)"""
+    s"""      .register($meta, $rpc _)"""
+  }
+
+  def endpointMetadata(md: MethodDescriptor): String = {
+    val prefix     = "/twirp"
+    val svc        = md.getService.getFullName
+    val methodName = getName(md)
+    s"""$EndpointMetadata("$prefix", "$svc", "$methodName")"""
   }
 
   def printService(printer: FunctionalPrinter): FunctionalPrinter = {
@@ -167,9 +171,7 @@ final class TwinagleServicePrinter(
     val inputType  = methodInputType(methodDescriptor)
     val outputType = methodOutputType(methodDescriptor)
     val methodName = decapitalizedName(methodDescriptor)
-    val (serviceName, rpcName) =
-      (methodDescriptor.getService.getFullName, getName(methodDescriptor))
-    val endpoint = s"""$EndpointMetadata("/twirp", "$serviceName", "$rpcName")"""
+    val endpoint   = endpointMetadata(methodDescriptor)
 
     s"""
        |  private val _${methodName}Service: $Service[$inputType, $outputType] = {
@@ -185,9 +187,7 @@ final class TwinagleServicePrinter(
     val inputType  = methodInputType(methodDescriptor)
     val outputType = methodOutputType(methodDescriptor)
     val methodName = decapitalizedName(methodDescriptor)
-    val (serviceName, rpcName) =
-      (methodDescriptor.getService.getFullName, getName(methodDescriptor))
-    val endpoint = s"""$EndpointMetadata("/twirp", "$serviceName", "$rpcName")"""
+    val endpoint   = endpointMetadata(methodDescriptor)
 
     s"""
        |  private val _${methodName}Service: $Service[$inputType, $outputType] = {

--- a/codegen/src/sbt-test/generator/e2e/src/main/protobuf/multi_service.proto
+++ b/codegen/src/sbt-test/generator/e2e/src/main/protobuf/multi_service.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package proto.test;
+
+message Request {}
+
+message Response {}
+
+service Service1 {
+  rpc Rpc1(Request) returns (Response);
+}
+
+service Service2 {
+  rpc Rpc2(Request) returns (Response);
+}

--- a/codegen/src/sbt-test/generator/e2e/src/test/scala/proto/test/MultiServiceSpec.scala
+++ b/codegen/src/sbt-test/generator/e2e/src/test/scala/proto/test/MultiServiceSpec.scala
@@ -1,0 +1,32 @@
+package proto.test
+
+import com.twitter.util.{Await, Future}
+import com.soundcloud.twinagle.ServerBuilder
+
+import org.specs2.mutable.Specification
+
+class MultiServiceSpec extends Specification {
+  
+  val svc1 = new Service1Service {
+    override def rpc1(req: Request): Future[Response] = Future.value(Response())
+  }
+  
+  val svc2 = new Service2Service {
+    override def rpc2(req: Request): Future[Response] = Future.value(Response())
+  }
+
+
+
+  "ServerBuilder allows building services that support multiple Protobuf services" in {
+    val httpService = ServerBuilder()
+      .register(Service1Service.protoService(svc1))
+      .register(Service2Service.protoService(svc2))
+      .build
+
+    val svc1Client = new Service1ClientProtobuf(httpService)
+    val svc2Client = new Service2ClientProtobuf(httpService) 
+
+    Await.result(svc1Client.rpc1(Request())) ==== Response()
+    Await.result(svc2Client.rpc2(Request())) ==== Response()
+  }
+}

--- a/codegen/src/sbt-test/generator/e2e/src/test/scala/proto/test/MultiServiceSpec.scala
+++ b/codegen/src/sbt-test/generator/e2e/src/test/scala/proto/test/MultiServiceSpec.scala
@@ -19,8 +19,8 @@ class MultiServiceSpec extends Specification {
 
   "ServerBuilder allows building services that support multiple Protobuf services" in {
     val httpService = ServerBuilder()
-      .register(Service1Service.protoService(svc1))
-      .register(Service2Service.protoService(svc2))
+      .register(svc1)
+      .register(svc2)
       .build
 
     val svc1Client = new Service1ClientProtobuf(httpService)

--- a/runtime/src/main/scala/com/soundcloud/twinagle/ProtoService.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/ProtoService.scala
@@ -1,0 +1,22 @@
+package com.soundcloud.twinagle
+
+import com.twitter.finagle.Service
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.util.Future
+import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
+
+case class ProtoService(rpcs: Seq[ProtoRpc]) {
+  assert(rpcs.map(_.metadata.service).toSet.size == 1, "inconsistent services in metadata")
+  assert(rpcs.map(_.metadata.prefix).toSet.size == 1, "inconsistent prefixes in metadata")
+}
+
+case class ProtoRpc(metadata: EndpointMetadata, svc: Service[Request, Response])
+object ProtoRpc {
+  def apply[
+      Req <: GeneratedMessage: GeneratedMessageCompanion,
+      Resp <: GeneratedMessage: GeneratedMessageCompanion
+  ](endpointMetadata: EndpointMetadata, rpc: Req => Future[Resp]): ProtoRpc = {
+    val httpService = new TwirpEndpointFilter[Req, Resp] andThen Service.mk(rpc)
+    ProtoRpc(endpointMetadata, httpService)
+  }
+}

--- a/runtime/src/main/scala/com/soundcloud/twinagle/ProtoService.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/ProtoService.scala
@@ -9,6 +9,9 @@ case class ProtoService(rpcs: Seq[ProtoRpc]) {
   assert(rpcs.map(_.metadata.service).toSet.size == 1, "inconsistent services in metadata")
   assert(rpcs.map(_.metadata.prefix).toSet.size == 1, "inconsistent prefixes in metadata")
 }
+object ProtoService {
+  implicit val asProtoService: AsProtoService[ProtoService] = (t: ProtoService) => t
+}
 
 case class ProtoRpc(metadata: EndpointMetadata, svc: Service[Request, Response])
 object ProtoRpc {

--- a/runtime/src/main/scala/com/soundcloud/twinagle/Server.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/Server.scala
@@ -9,15 +9,10 @@ import com.twitter.util.Future
   * TwinagleExceptions are returned as conformant JSON responses, other exceptions are mapped
   * to twirp internal errors.
   *
-  * TODO:
-  * - extensibility/observability (metrics, logging, tracing, exception tracking, etc)
-  * - do (de-)serialization errors need special handling?
-  *
-  * @param endpoints list of endpoints to expose
+  * @param endpoints list of protobuf RPCs to expose
   */
-private[twinagle] class Server(endpoints: Map[EndpointMetadata, Service[Request, Response]])
-    extends Service[Request, Response] {
-  private val servicesByPath = endpoints.map { case (k, v) => k.path -> v }
+private[twinagle] class Server(endpoints: Seq[ProtoRpc]) extends Service[Request, Response] {
+  private val servicesByPath = endpoints.map(rpc => rpc.metadata.path -> rpc.svc).toMap
 
   override def apply(request: Request): Future[Response] =
     request.method match {

--- a/runtime/src/main/scala/com/soundcloud/twinagle/ServerBuilder.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/ServerBuilder.scala
@@ -13,7 +13,7 @@ case class ServerBuilder(
   }
 
   def build: Service[Request, Response] =
-    new Server(endpoints.map(instrument).map(rpc => rpc.metadata -> rpc.svc).toMap)
+    new Server(endpoints.map(instrument))
 
   private def instrument(rpc: ProtoRpc): ProtoRpc =
     rpc.copy(

--- a/runtime/src/main/scala/com/soundcloud/twinagle/ServerBuilder.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/ServerBuilder.scala
@@ -8,7 +8,8 @@ case class ServerBuilder(
     endpoints: Seq[ProtoRpc] = Seq.empty
 ) {
 
-  def register(protoService: ProtoService): ServerBuilder = {
+  def register[T: AsProtoService](svc: T): ServerBuilder = {
+    val protoService = implicitly[AsProtoService[T]].asProtoService(svc)
     this.copy(endpoints = endpoints ++ protoService.rpcs)
   }
 
@@ -22,4 +23,8 @@ case class ServerBuilder(
         rpc.svc
     )
 
+}
+
+trait AsProtoService[T] {
+  def asProtoService(t: T): ProtoService
 }

--- a/runtime/src/test/scala/com/soundcloud/twinagle/ServerSpec.scala
+++ b/runtime/src/test/scala/com/soundcloud/twinagle/ServerSpec.scala
@@ -1,7 +1,6 @@
 package com.soundcloud.twinagle
 
 import com.soundcloud.twinagle.test.TestMessage
-import com.twitter.finagle.Filter
 import com.twitter.finagle.http.{MediaType, Method, Request, Status}
 import com.twitter.util.{Await, Future}
 import org.specs2.mock.Mockito
@@ -11,8 +10,13 @@ import org.specs2.specification.Scope
 class ServerSpec extends Specification with Mockito {
   trait Context extends Scope {
     val rpc = mock[TestMessage => Future[TestMessage]]
-    val server = ServerBuilder(_ => Filter.TypeAgnostic.Identity)
-      .register(EndpointMetadata("/twirp", "svc", "rpc"), rpc)
+    val protoService = ProtoService(
+      Seq(
+        ProtoRpc(EndpointMetadata("/twirp", "svc", "rpc"), rpc)
+      )
+    )
+    val server = ServerBuilder()
+      .register(protoService)
       .build
   }
 


### PR DESCRIPTION
This change makes `ServerBuilder` more "officially" part of Twinagle's API.

runtime:
- introduce `ProtoService`/`ProtoRpc` model to represent protobuf services and their RPC methods
- modify ServerBuilder to register `ProtoService`s instead of individual metadata/method pairs
- make all `ServerBuilder` parameters optional

codegen:
- introduce `MyService.protoService(impl)` factory to create `ProtoService` representation of `MyService`.
- modify `MyService.server()` to use `protoService` under the hood.

Fixes #123 

