### PR TITLE
remove support for customizeable prefix

### DIFF
--- a/codegen/src/main/scala/com/soundcloud/twinagle/codegen/TwinagleServicePrinter.scala
+++ b/codegen/src/main/scala/com/soundcloud/twinagle/codegen/TwinagleServicePrinter.scala
@@ -49,10 +49,9 @@ final class TwinagleServicePrinter(
   }
 
   def endpointMetadata(md: MethodDescriptor): String = {
-    val prefix     = "/twirp"
     val svc        = md.getService.getFullName
     val methodName = getName(md)
-    s"""$EndpointMetadata("$prefix", "$svc", "$methodName")"""
+    s"""$EndpointMetadata("$svc", "$methodName")"""
   }
 
   def printService(printer: FunctionalPrinter): FunctionalPrinter = {

--- a/runtime/src/main/scala/com/soundcloud/twinagle/EndpointMetadata.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/EndpointMetadata.scala
@@ -3,14 +3,11 @@ package com.soundcloud.twinagle
 /**
   * Endpoint represents a Twirp RPC endpoint.
   *
-  * @param prefix  prefix of all twirp services. Usually, "/twirp".
   * @param service absolute name of the Twirp service.
   * @param rpc     name of the RPC endpoint within the Twirp service.
   */
-case class EndpointMetadata(prefix: String, service: String, rpc: String) {
-  require(prefix.startsWith("/"))
-  require(!prefix.endsWith("/"))
+case class EndpointMetadata(service: String, rpc: String) {
 
   /** @return the (absolute) HTTP path of the RPC endpoint. */
-  def path = s"$prefix/$service/$rpc"
+  def path = s"/twirp/$service/$rpc"
 }

--- a/runtime/src/main/scala/com/soundcloud/twinagle/ProtoService.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/ProtoService.scala
@@ -7,7 +7,6 @@ import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 
 case class ProtoService(rpcs: Seq[ProtoRpc]) {
   assert(rpcs.map(_.metadata.service).toSet.size == 1, "inconsistent services in metadata")
-  assert(rpcs.map(_.metadata.prefix).toSet.size == 1, "inconsistent prefixes in metadata")
 }
 object ProtoService {
   implicit val asProtoService: AsProtoService[ProtoService] = (t: ProtoService) => t

--- a/runtime/src/main/scala/com/soundcloud/twinagle/TracingFilter.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/TracingFilter.scala
@@ -9,7 +9,6 @@ private[twinagle] class TracingFilter[In, Out](
 ) extends SimpleFilter[In, Out] {
   override def apply(request: In, service: Service[In, Out]): Future[Out] = {
     val trace = Trace()
-    trace.recordBinary(TracingFilter.Prefix, endpointMetadata.prefix)
     trace.recordBinary(TracingFilter.Service, endpointMetadata.service)
     trace.recordBinary(TracingFilter.Rpc, endpointMetadata.rpc)
 
@@ -26,7 +25,6 @@ private[twinagle] class TracingFilter[In, Out](
 
 object TracingFilter {
   val Service = "twirp.service"
-  val Prefix  = "twirp.prefix"
   val Rpc     = "twirp.rpc"
 
   val Error        = "error"

--- a/runtime/src/test/scala/com/soundcloud/twinagle/ServerSpec.scala
+++ b/runtime/src/test/scala/com/soundcloud/twinagle/ServerSpec.scala
@@ -12,7 +12,7 @@ class ServerSpec extends Specification with Mockito {
     val rpc = mock[TestMessage => Future[TestMessage]]
     val protoService = ProtoService(
       Seq(
-        ProtoRpc(EndpointMetadata("/twirp", "svc", "rpc"), rpc)
+        ProtoRpc(EndpointMetadata("svc", "rpc"), rpc)
       )
     )
     val server = ServerBuilder()

--- a/runtime/src/test/scala/com/soundcloud/twinagle/TracingFilterSpec.scala
+++ b/runtime/src/test/scala/com/soundcloud/twinagle/TracingFilterSpec.scala
@@ -25,12 +25,11 @@ class TracingFilterSpec extends Specification {
   "adds annotations" >> {
     "successful request" in new Context {
       Trace.letTracer(tracer) {
-        val svc = new TracingFilter(EndpointMetadata("/twirp", "svc", "rpc")) andThen
+        val svc = new TracingFilter(EndpointMetadata("svc", "rpc")) andThen
           Service.const(Future.value(response))
         Await.result(svc(request))
       }
 
-      binaryAnnotations.get(TracingFilter.Prefix) ==== Some("/twirp")
       binaryAnnotations.get(TracingFilter.Service) ==== Some("svc")
       binaryAnnotations.get(TracingFilter.Rpc) ==== Some("rpc")
 
@@ -42,12 +41,11 @@ class TracingFilterSpec extends Specification {
     "twinagle errors" in new Context {
       val exception = TwinagleException(ErrorCode.NotFound, "foo not found")
       Trace.letTracer(tracer) {
-        val svc = new TracingFilter(EndpointMetadata("/twirp", "svc", "rpc")) andThen
+        val svc = new TracingFilter(EndpointMetadata("svc", "rpc")) andThen
           Service.const(Future.exception(exception))
         Await.result(svc(request).liftToTry)
       }
 
-      binaryAnnotations.get(TracingFilter.Prefix) ==== Some("/twirp")
       binaryAnnotations.get(TracingFilter.Service) ==== Some("svc")
       binaryAnnotations.get(TracingFilter.Rpc) ==== Some("rpc")
 
@@ -61,7 +59,7 @@ class TracingFilterSpec extends Specification {
     "other errors" in new Context {
       val exception = new RuntimeException("boom")
       Trace.letTracer(tracer) {
-        val svc = new TracingFilter(EndpointMetadata("/twirp", "svc", "rpc")) andThen
+        val svc = new TracingFilter(EndpointMetadata("svc", "rpc")) andThen
           Service.const(Future.exception(exception))
         Await.result(svc(request).liftToTry)
       }


### PR DESCRIPTION
upstream Twirp [has decided](https://github.com/twitchtv/twirp/blob/master/docs/spec_v6.md) not to continue work on Twirp
protocol version 6, and committed to remaining backwards
compatible instead.

This means that endpoints will always have the `/twirp` prefix,
so we can just hardcode it in `EndpointMetadata.path`.