### PR TITLE
run release build when publishing releases

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -2,6 +2,9 @@ on:
   push:
     branches:
     - master
+  release:
+    types:
+    - published
 
 jobs:
   build:


### PR DESCRIPTION
it looks like the build didn't get triggered for the v0.7.0 release. Not really sure why the v0.6.0 release worked successfully, afair, we released that from github, too.