### PR TITLE
fix codegen for services with multiple RPCs

### DIFF
--- a/codegen/src/main/scala/com/soundcloud/twinagle/codegen/TwinagleServicePrinter.scala
+++ b/codegen/src/main/scala/com/soundcloud/twinagle/codegen/TwinagleServicePrinter.scala
@@ -32,7 +32,7 @@ final class TwinagleServicePrinter(
     s"""
        |object $serviceName {
        |  implicit val asProtoService: $AsProtoService[$serviceName] = (service: $serviceName) => $ProtoService(Seq(
-       |${m.methods.map(protoRpc).mkString("\n")}
+       |${m.methods.map(protoRpc).mkString(",\n")}
        |  ))
        |
        |  def server(service: $serviceName,

--- a/codegen/src/sbt-test/generator/e2e/src/main/protobuf/multi_method_service.proto
+++ b/codegen/src/sbt-test/generator/e2e/src/main/protobuf/multi_method_service.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package proto.test;
+
+message MMRequest {}
+
+message MMResponse {}
+
+service MultiMethod {
+  rpc Rpc1(MMRequest) returns (MMResponse);
+  rpc Rpc2(MMRequest) returns (MMResponse);
+}

--- a/codegen/src/sbt-test/generator/e2e/src/test/scala/proto/test/MultiMethodServiceSpec.scala
+++ b/codegen/src/sbt-test/generator/e2e/src/test/scala/proto/test/MultiMethodServiceSpec.scala
@@ -1,0 +1,26 @@
+package proto.test
+
+import com.twitter.util.Future
+import com.soundcloud.twinagle.ServerBuilder
+
+import org.specs2.mutable.Specification
+
+class MultiMethodServiceSpec extends Specification {
+
+  // if this compiles, we're good
+  "ServerBuilder allows building services that contain multiple RPCs" in {
+    val svc = new MultiMethodService {
+      override def rpc1(req: MMRequest): Future[MMResponse] = Future.value(MMResponse())
+      override def rpc2(req: MMRequest): Future[MMResponse] = Future.value(MMResponse())
+    }
+
+
+    val httpService = ServerBuilder()
+      .register(svc)
+      .build
+
+    new MultiMethodClientProtobuf(httpService)
+    new MultiMethodClientJson(httpService)
+    ok
+  }
+}


### PR DESCRIPTION
#132 introduced a bug that caused the code generator to emit bad code for services that expose multiple RPCs. This change fixes the error and adds a test case to avoid future regressions.