### PR TITLE
Translate cancelled requests

### DIFF
--- a/runtime/src/main/scala/com/soundcloud/twinagle/Server.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/Server.scala
@@ -22,7 +22,7 @@ private[twinagle] class Server(endpoints: Seq[ProtoRpc]) extends Service[Request
             service(request).handle {
               case e: TwinagleException => errorResponse(e)
               case e: CancelledRequestException =>
-                errorResponse(new TwinagleException(ErrorCode.Canceled, "Request canceled by client"))
+                errorResponse(TwinagleException(ErrorCode.Canceled, "Request canceled by client"))
               case e => errorResponse(new TwinagleException(e))
             }
           case None =>

--- a/runtime/src/main/scala/com/soundcloud/twinagle/Server.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/Server.scala
@@ -1,6 +1,6 @@
 package com.soundcloud.twinagle
 
-import com.twitter.finagle.Service
+import com.twitter.finagle.{CancelledRequestException, Service}
 import com.twitter.finagle.http._
 import com.twitter.util.Future
 
@@ -21,7 +21,9 @@ private[twinagle] class Server(endpoints: Seq[ProtoRpc]) extends Service[Request
           case Some(service) =>
             service(request).handle {
               case e: TwinagleException => errorResponse(e)
-              case e                    => errorResponse(new TwinagleException(e))
+              case e: CancelledRequestException =>
+                errorResponse(new TwinagleException(ErrorCode.Canceled, "Request canceled by client"))
+              case e => errorResponse(new TwinagleException(e))
             }
           case None =>
             Future.value(

--- a/runtime/src/test/scala/com/soundcloud/twinagle/ServerSpec.scala
+++ b/runtime/src/test/scala/com/soundcloud/twinagle/ServerSpec.scala
@@ -99,7 +99,7 @@ class ServerSpec extends Specification with Mockito {
     "translates Finagle cancelled request exceptions into Twirp canceled" in new Context {
       val request = httpRequest()
       val ex      = new CancelledRequestException()
-      rpc.apply(any) answers { _ => throw ex }
+      rpc.apply(any) throws ex
 
       val response = Await.result(server(request))
 

--- a/runtime/src/test/scala/com/soundcloud/twinagle/ServerSpec.scala
+++ b/runtime/src/test/scala/com/soundcloud/twinagle/ServerSpec.scala
@@ -99,7 +99,7 @@ class ServerSpec extends Specification with Mockito {
     "translates Finagle cancelled request exceptions into Twirp canceled" in new Context {
       val request = httpRequest()
       val ex      = new CancelledRequestException()
-      rpc.apply(any) throws ex
+      rpc.apply(any) returns Future.exception(ex)
 
       val response = Await.result(server(request))
 

--- a/runtime/src/test/scala/com/soundcloud/twinagle/ServerSpec.scala
+++ b/runtime/src/test/scala/com/soundcloud/twinagle/ServerSpec.scala
@@ -7,6 +7,8 @@ import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 
+import com.twitter.finagle.CancelledRequestException
+
 class ServerSpec extends Specification with Mockito {
   trait Context extends Scope {
     val rpc = mock[TestMessage => Future[TestMessage]]
@@ -92,6 +94,19 @@ class ServerSpec extends Specification with Mockito {
       response.status ==== Status.InternalServerError
       response.contentString must contain(ErrorCode.Internal.desc)
       response.contentString must contain(ex.toString)
+    }
+
+    "translates Finagle cancelled request exceptions into Twirp canceled" in new Context {
+      val request = httpRequest()
+      val ex      = new CancelledRequestException()
+      rpc.apply(any) answers { _ => throw ex }
+
+      val response = Await.result(server(request))
+
+      there was exactly(1)(rpc).apply(TestMessage())
+      response.status ==== Status.RequestTimeout
+      response.contentString must contain(ErrorCode.Canceled.desc)
+      response.contentString must contain("Request canceled by client")
     }
   }
 }


### PR DESCRIPTION
When the client cancels a request, the server responds with a cancelled
response (that will never be seen by the client).