### PR TITLE
Throw bare exception in CancelledRequestException example

### DIFF
--- a/runtime/src/test/scala/com/soundcloud/twinagle/ServerSpec.scala
+++ b/runtime/src/test/scala/com/soundcloud/twinagle/ServerSpec.scala
@@ -99,7 +99,7 @@ class ServerSpec extends Specification with Mockito {
     "translates Finagle cancelled request exceptions into Twirp canceled" in new Context {
       val request = httpRequest()
       val ex      = new CancelledRequestException()
-      rpc.apply(any) returns Future.exception(ex)
+      rpc.apply(any) answers { _: Array[AnyRef] => throw ex }
 
       val response = Await.result(server(request))
 


### PR DESCRIPTION
Perhaps `CancelledRequestException`s are always wrapped in a `Future`, but if that can't be guaranteed, this will work with Scala 2.13.1.

However, I also wonder why Mockito complains with `Checked exception is invalid for this method!` when attempting to use `throws` to achieve the same effect. Is this due to the difference in ancestry between `RuntimeException` (which works well in another example) and `CancelledRequestException`. I don't understand how Mockito decides which types of execption can be raised from a Scala function defined only as (`A => B`), I would expect it to be allowed to raise any descendant of `Exception`.