### PR TITLE
json handling of unknown fields

### DIFF
--- a/runtime/src/main/scala/com/soundcloud/twinagle/JsonClientFilter.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/JsonClientFilter.scala
@@ -13,7 +13,7 @@ private[twinagle] class JsonClientFilter[
     path: String
 ) extends Filter[Req, Rep, Request, Response] {
 
-  val jsonParser = new Parser().ignoringUnknownFields
+  private val jsonParser = new Parser().ignoringUnknownFields
 
   override def apply(
       request: Req,

--- a/runtime/src/main/scala/com/soundcloud/twinagle/JsonClientFilter.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/JsonClientFilter.scala
@@ -3,7 +3,7 @@ package com.soundcloud.twinagle
 import com.twitter.finagle.http.{MediaType, Method, Request, Response}
 import com.twitter.finagle.{Filter, Service}
 import com.twitter.util.Future
-import scalapb.json4s.JsonFormat
+import scalapb.json4s.{JsonFormat, Parser}
 import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 
 private[twinagle] class JsonClientFilter[
@@ -12,6 +12,9 @@ private[twinagle] class JsonClientFilter[
 ](
     path: String
 ) extends Filter[Req, Rep, Request, Response] {
+
+  val jsonParser = new Parser().ignoringUnknownFields
+
   override def apply(
       request: Req,
       service: Service[Request, Response]
@@ -28,6 +31,6 @@ private[twinagle] class JsonClientFilter[
   }
 
   def deserializeResponse(response: Response): Rep = {
-    JsonFormat.fromJsonString[Rep](response.contentString)
+    jsonParser.fromJsonString[Rep](response.contentString)
   }
 }

--- a/runtime/src/main/scala/com/soundcloud/twinagle/TwirpEndpointFilter.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/TwirpEndpointFilter.scala
@@ -4,7 +4,7 @@ import com.twitter.finagle.http.{MediaType, Request, Response, Status}
 import com.twitter.finagle.{Filter, Service}
 import com.twitter.io.Buf
 import com.twitter.util.Future
-import scalapb.json4s.{JsonFormat, Parser, Printer}
+import scalapb.json4s.{Parser, Printer}
 import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 
 /**

--- a/runtime/src/main/scala/com/soundcloud/twinagle/TwirpEndpointFilter.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/TwirpEndpointFilter.scala
@@ -18,8 +18,8 @@ private[twinagle] class TwirpEndpointFilter[
     Rep <: GeneratedMessage: GeneratedMessageCompanion
 ] extends Filter[Request, Response, Req, Rep] {
 
-  val jsonParser = new Parser().ignoringUnknownFields
-  val printer = new Printer().includingDefaultValueFields
+  private val jsonParser = new Parser().ignoringUnknownFields
+  private val printer = new Printer().includingDefaultValueFields
 
   override def apply(
       request: Request,

--- a/runtime/src/test/protobuf/unknown_fields.proto
+++ b/runtime/src/test/protobuf/unknown_fields.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package proto.test;
+package com.soundcloud.twinagle;
 
 // this represents a "new version" of Test1 that has a new field
 message Test2 {

--- a/runtime/src/test/scala/com/soundcloud/twinagle/TwirpEndpointFilterSpec.scala
+++ b/runtime/src/test/scala/com/soundcloud/twinagle/TwirpEndpointFilterSpec.scala
@@ -72,7 +72,7 @@ class TwirpEndpointFilterSpec extends Specification {
         response.contentString ==== """{"foo":0}"""
       }
 
-      "round-trips unknown fields" in new Context {
+      "ignores unknown fields" in new Context {
         val request = Request()
         request.contentType = "application/json; charset=UTF-8"
         request.contentString = """{"foo": 123}"""
@@ -80,7 +80,7 @@ class TwirpEndpointFilterSpec extends Specification {
         val response = Await.result(svc(request))
 
         response.status ==== Status.Ok
-        response.contentString ==== """{"foo": 123}"""
+        response.contentString ==== "{}"
       }
     }
 

--- a/runtime/src/test/scala/com/soundcloud/twinagle/TwirpEndpointFilterSpec.scala
+++ b/runtime/src/test/scala/com/soundcloud/twinagle/TwirpEndpointFilterSpec.scala
@@ -57,7 +57,7 @@ class TwirpEndpointFilterSpec extends Specification {
         response.status ==== Status.Ok
         response.contentString ==== "{}"
       }
-      
+
       "serializes default values" in {
         val svc = new TwirpEndpointFilter[HasField, HasField] andThen
           Service.mk[HasField, HasField](msg => Future.value(msg))
@@ -70,6 +70,17 @@ class TwirpEndpointFilterSpec extends Specification {
 
         response.status ==== Status.Ok
         response.contentString ==== """{"foo":0}"""
+      }
+
+      "round-trips unknown fields" in new Context {
+        val request = Request()
+        request.contentType = "application/json; charset=UTF-8"
+        request.contentString = """{"foo": 123}"""
+
+        val response = Await.result(svc(request))
+
+        response.status ==== Status.Ok
+        response.contentString ==== """{"foo": 123}"""
       }
     }
 

--- a/runtime/src/test/scala/com/soundcloud/twinagle/UnknownFieldsSpec.scala
+++ b/runtime/src/test/scala/com/soundcloud/twinagle/UnknownFieldsSpec.scala
@@ -5,7 +5,7 @@ import scalapb.json4s.{JsonFormat, Parser}
 
 class UnknownFieldsSpec extends Specification{
 
-  "should propagate unknown fields" in {
+  "binary protobuf propagates unknown fields" in {
     val original = Test2(foo = 1, bar = 2)
 
     val intermediate = Test1.parseFrom(original.toByteArray)
@@ -15,16 +15,16 @@ class UnknownFieldsSpec extends Specification{
     roundtripped ==== original
   }
 
-  "JSON (de)serialization should propagate unknown fields" in {
+  "JSON parsing ignores unknown fields" in {
     val original = Test2(foo = 1, bar = 2)
 
     val parser = new Parser().ignoringUnknownFields
 
     val intermediate = parser.fromJsonString[Test1](JsonFormat.toJsonString(original))
-    intermediate.foo ==== original.foo // this works
+    intermediate.foo ==== original.foo
 
     val roundtripped = parser.fromJsonString[Test2](JsonFormat.toJsonString(intermediate))
-    roundtripped ==== original // broken because unknown fields are ignored
+    roundtripped ==== original.copy(bar = 0) // unknown fields are ignored
   }
 
 }

--- a/runtime/src/test/scala/com/soundcloud/twinagle/UnknownFieldsSpec.scala
+++ b/runtime/src/test/scala/com/soundcloud/twinagle/UnknownFieldsSpec.scala
@@ -1,7 +1,7 @@
 package com.soundcloud.twinagle
 
 import org.specs2.mutable.Specification
-import scalapb.json4s.JsonFormat
+import scalapb.json4s.{JsonFormat, Parser}
 
 class UnknownFieldsSpec extends Specification{
 
@@ -18,11 +18,13 @@ class UnknownFieldsSpec extends Specification{
   "JSON (de)serialization should propagate unknown fields" in {
     val original = Test2(foo = 1, bar = 2)
 
-    val intermediate = JsonFormat.fromJsonString[Test1](JsonFormat.toJsonString(original))
-    intermediate.foo ==== original.foo
+    val parser = new Parser().ignoringUnknownFields
 
-    val roundtripped = JsonFormat.fromJsonString[Test2](JsonFormat.toJsonString(intermediate))
-    roundtripped ==== original
+    val intermediate = parser.fromJsonString[Test1](JsonFormat.toJsonString(original))
+    intermediate.foo ==== original.foo // this works
+
+    val roundtripped = parser.fromJsonString[Test2](JsonFormat.toJsonString(intermediate))
+    roundtripped ==== original // broken because unknown fields are ignored
   }
 
 }

--- a/runtime/src/test/scala/com/soundcloud/twinagle/UnknownFieldsSpec.scala
+++ b/runtime/src/test/scala/com/soundcloud/twinagle/UnknownFieldsSpec.scala
@@ -1,6 +1,7 @@
-package proto.test
+package com.soundcloud.twinagle
 
 import org.specs2.mutable.Specification
+import scalapb.json4s.JsonFormat
 
 class UnknownFieldsSpec extends Specification{
 

--- a/runtime/src/test/scala/com/soundcloud/twinagle/UnknownFieldsSpec.scala
+++ b/runtime/src/test/scala/com/soundcloud/twinagle/UnknownFieldsSpec.scala
@@ -15,4 +15,14 @@ class UnknownFieldsSpec extends Specification{
     roundtripped ==== original
   }
 
+  "JSON (de)serialization should propagate unknown fields" in {
+    val original = Test2(foo = 1, bar = 2)
+
+    val intermediate = JsonFormat.fromJsonString[Test1](JsonFormat.toJsonString(original))
+    intermediate.foo ==== original.foo
+
+    val roundtripped = JsonFormat.fromJsonString[Test2](JsonFormat.toJsonString(intermediate))
+    roundtripped ==== original
+  }
+
 }


### PR DESCRIPTION
currently, twinagle produces internal errors when incoming JSON requests contain unknown fields.
Instead, we configure the JSON parser to ignore and discard the unknown fields.
In contrast, when using binary protobuf, unknown fields are preserved and propagated.
This difference in behaviour is by design in ScalaPB, which follows the java-protobuf implementation.

See-Also: https://groups.google.com/g/scalapb/c/zRRii_xL-_w