### PR TITLE
allow empty path prefix

### DIFF
--- a/runtime/src/main/scala/com/soundcloud/twinagle/ClientEndpointBuilder.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/ClientEndpointBuilder.scala
@@ -10,8 +10,10 @@ class ClientEndpointBuilder(
     prefix: String
 ) {
 
-  require(prefix.startsWith("/"), "prefix must start with slash")
-  require(!prefix.endsWith("/"), "prefix must not end with slash")
+  if (prefix.nonEmpty) {
+    require(prefix.startsWith("/"), "prefix must start with slash")
+    require(!prefix.endsWith("/"), "prefix must not end with slash")
+  }
 
   def jsonEndpoint[
       Req <: GeneratedMessage,

--- a/runtime/src/main/scala/com/soundcloud/twinagle/ServerBuilder.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/ServerBuilder.scala
@@ -9,8 +9,10 @@ case class ServerBuilder(
     prefix: String = "/twirp"
 ) {
 
-  require(prefix.startsWith("/"), "prefix must start with slash")
-  require(!prefix.endsWith("/"), "prefix must not end with slash")
+  if (prefix.nonEmpty) {
+    require(prefix.startsWith("/"), "prefix must start with slash")
+    require(!prefix.endsWith("/"), "prefix must not end with slash")
+  }
 
   def register[T: AsProtoService](svc: T): ServerBuilder = {
     val protoService = implicitly[AsProtoService[T]].asProtoService(svc)

--- a/runtime/src/test/scala/com/soundcloud/twinagle/ClientEndpointBuilderSpec.scala
+++ b/runtime/src/test/scala/com/soundcloud/twinagle/ClientEndpointBuilderSpec.scala
@@ -1,0 +1,44 @@
+package com.soundcloud.twinagle
+
+import com.twitter.util.Future
+import com.twitter.finagle.{Filter, Service}
+import com.twitter.finagle.http.{Request, Response}
+import org.specs2.mutable.Specification
+
+class ClientEndpointBuilderSpec extends Specification {
+
+  val httpClient: Service[Request, Response] =
+    Service.mk(_ => Future.value(Response()))
+  val extension: EndpointMetadata => Filter.TypeAgnostic =
+    _ => Filter.TypeAgnostic.Identity
+
+  "prefix validation" >> {
+
+    "default works" in {
+      new ClientEndpointBuilder(httpClient, extension, "/twirp") must not(throwAn[IllegalArgumentException])
+    }
+
+    "custom path works" in {
+      new ClientEndpointBuilder(httpClient, extension, prefix = "/somewhere/else") must not(throwAn[IllegalArgumentException])
+    }
+
+    "empty prefix" in {
+      new ClientEndpointBuilder(httpClient, extension, prefix = "") must not(throwAn[IllegalArgumentException])
+    }
+
+    "invalid cases" >> {
+      "/ (use empty string)" in {
+        new ClientEndpointBuilder(httpClient, extension, prefix = "/") must throwAn[IllegalArgumentException]
+      }
+
+      "relative path" in {
+        new ClientEndpointBuilder(httpClient, extension, prefix = "relative/path") must throwAn[IllegalArgumentException]
+      }
+
+      "ends with slash" in {
+        new ClientEndpointBuilder(httpClient, extension, prefix = "/some/path/") must throwAn[IllegalArgumentException]
+      }
+    }
+
+  }
+}

--- a/runtime/src/test/scala/com/soundcloud/twinagle/ServerBuilderSpec.scala
+++ b/runtime/src/test/scala/com/soundcloud/twinagle/ServerBuilderSpec.scala
@@ -1,0 +1,44 @@
+package com.soundcloud.twinagle
+
+import org.specs2.mutable.Specification
+
+class ServerBuilderSpec extends Specification {
+  "prefix validation" >> {
+
+    "default works" in {
+      ServerBuilder() must not(throwAn[IllegalArgumentException])
+    }
+
+    "custom path works" in {
+      ServerBuilder(prefix = "/somewhere/else") must not(throwAn[IllegalArgumentException])
+    }
+
+    "empty prefix" in {
+      ServerBuilder(prefix = "") must not(throwAn[IllegalArgumentException])
+    }
+
+    "invalid cases" >> {
+      "/ (use empty string)" in {
+        ServerBuilder(prefix = "/") must throwAn[IllegalArgumentException]
+      }
+
+      "relative path" in {
+        ServerBuilder(prefix = "relative/path") must throwAn[IllegalArgumentException]
+      }
+
+      "ends with slash" in {
+        ServerBuilder(prefix = "/some/path/") must throwAn[IllegalArgumentException]
+      }
+
+      "copy method validates" in {
+        ServerBuilder().copy(prefix = "/invalid/") must throwAn[IllegalArgumentException]
+      }
+
+      "withPrefix method validates" in {
+        ServerBuilder().withPrefix("/invalid/") must throwAn[IllegalArgumentException]
+      }
+    }
+
+
+  }
+}


### PR DESCRIPTION
follow-up for #182.

the original request for customizeable prefixes was to
allow omitting the `/twirp` prefix entirely. We should
support that, too.

Add tests for prefix validation.