### PR TITLE
Prevent duplicate CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 on:
   push:
+    branches:
+      - master
   pull_request:
   release:
     types:


### PR DESCRIPTION
Don't build on non-master pushes since `pull_request` already covers
that.

Example: https://github.com/twitter/finagle/blob/develop/.github/workflows/continuous-integration.yml#L10-L15