### PR TITLE
[Proposal] Remove exception mapping

### DIFF
--- a/runtime/src/main/scala/com/soundcloud/twinagle/Server.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/Server.scala
@@ -24,7 +24,6 @@ private[twinagle] class Server(endpoints: Seq[ProtoRpc], prefix: String) extends
               case e: TwinagleException => errorResponse(e)
               case CancelledCategorizer(_) =>
                 errorResponse(TwinagleException(ErrorCode.Canceled, "Request canceled by client"))
-              case e => errorResponse(new TwinagleException(e))
             }
           case None =>
             Future.value(


### PR DESCRIPTION
Currently we map all exceptions to failed HTTP responses (using Twirp error protocol). This creates some issues for existing exception collection mechanism. Indeed we collect errors twice:
* First in [ServerTelemetery](https://github.com/soundcloud/jvmkit-modules/blob/master/jvmkit-twirp/src/main/scala/com/soundcloud/jvmkit/module/twirp/filters/ServerTelemetry.scala#L64)
* Then twinagle Server [maps](https://github.com/soundcloud/twinagle/blob/master/runtime/src/main/scala/com/soundcloud/twinagle/Server.scala#L27) such exception into a failed response. This failed response latter is collected again by [ExceptionCollectorFilter](https://github.com/soundcloud/jvmkit-modules/blob/master/jvmkit-http-server/src/main/scala/com/soundcloud/jvmkit/module/http/server/filters/ExceptionCollectorFilter.scala#L52).

As result we have almost duplicated entries in Periscope for a single failure. Moreover the exception that collected in twinagle won't have request payload attached that will things even more confusing.

This PR proposes to remove mapping of generic exceptions to failed responses. Instead we can reuse existing [ExceptionHandlerFilter](https://github.com/soundcloud/jvmkit-modules/blob/master/jvmkit-http-server/src/main/scala/com/soundcloud/jvmkit/module/http/server/filters/ExceptionHandlerFilter.scala) but modify it so it will alway response with response that is compatible with Twirp protocol 

See https://github.com/soundcloud/jvmkit-modules/pull/692