### PR TITLE
Fix codegen target paths

### DIFF
--- a/codegen/src/main/scala/com/soundcloud/twinagle/codegen/Twinagle.scala
+++ b/codegen/src/main/scala/com/soundcloud/twinagle/codegen/Twinagle.scala
@@ -20,11 +20,11 @@ object Twinagle extends AutoPlugin {
     Compile / PB.targets := Seq(
       Target(
         scalapb.gen(scalapbCodeGeneratorOptions.value - scalapb.GeneratorOption.Grpc),
-        (Compile / sourceManaged).value
+        (Compile / sourceManaged).value / "twinagle-protobuf"
       ),
       Target(
         JvmGenerator("scala-twinagle", ServerClientCodeGenerator),
-        (Compile / sourceManaged).value,
+        (Compile / sourceManaged).value / "twinagle-services",
         scalapb.gen(scalapbCodeGeneratorOptions.value)._2
       )
     ),


### PR DESCRIPTION
Before this change we would write the ScalaPB-generated code directly to
`sourceManaged`. This works fine until another library/app writes to
that directory. It seems like ScalaPB deletes all contents in its
specified target directory, therefore removing any other code that might
also live there.

To fix this, we now write the generated code in twinagle-specific
subdirectories. By doing that, ScalaPB only cleans our own directories,
leaving other subdirs in the main `sourceManaged` directory alone.

This change is fully backwards-compatible, no code-changes are needed.
You might have to run `sbt clean` once in the target project though
to prevent duplicate files.