### PR TITLE
Upgrade scalapb-json4s to v0.12.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,8 @@ lazy val runtime = (project in file("runtime")).settings(
   libraryDependencies ++= Seq(
     "com.twitter"          %% "finagle-http"    % "21.6.0",
     "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion,
-    "com.thesamet.scalapb" %% "scalapb-json4s" % "0.11.1",
+    "com.thesamet.scalapb" %% "scalapb-json4s"  % "0.12.0",
+    "org.json4s"           %% "json4s-native"   % "4.0.1",
 
     "org.specs2" %% "specs2-core" % "4.12.3" % Test,
     "org.specs2" %% "specs2-mock" % "4.12.3" % Test

--- a/runtime/src/main/scala/com/soundcloud/twinagle/JsonError.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/JsonError.scala
@@ -15,8 +15,8 @@ private[twinagle] object JsonError {
   // we use json4s because we depend on it already via scalapb-runtime.
 
   import org.json4s._
-  import org.json4s.jackson.Serialization
-  import org.json4s.jackson.Serialization.{read, write}
+  import org.json4s.native.Serialization
+  import org.json4s.native.Serialization.{read, write}
 
   import scala.util.control.Exception._
   implicit val formats = Serialization.formats(NoTypeHints)


### PR DESCRIPTION
Upgrade to scalapb-json4s to v0.12.0.

Add json4s-jackson dependency since scalapb-json4s now only depends on
json4s-jackson-core which does not include the classes that we use.
Since we already depend on jackson (via finagle) this should be fine.

Closes #255.