### PR TITLE
Upgrade to scalafmt v3.1.0

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,6 @@
-version=3.0.8
+version=3.1.0
+
+runner.dialect = scala212
 
 align.preset = "more"
 


### PR DESCRIPTION
And se the now mandatory `runner.dialect` setting.
We use scala 2.12 since we cross-build for both 2.12 and 2.13 at the
moment.