### PR TITLE
Add support for 'optional' in proto3 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,6 @@ Please ensure that `sbt scalafmtCheckAll +test scripted` passes when submitting 
 
 * IntelliJ [doesn't run plugins][intellij] during project build. Before importing,
  `sbt compile` may be necessary.
+
+* In order to run the full test suite (i.e. the unit tests & the end-to-end tests
+ for code-generation) use `sbt +test scripted`

--- a/codegen/src/main/scala/com/soundcloud/twinagle/codegen/ServerClientCodeGenerator.scala
+++ b/codegen/src/main/scala/com/soundcloud/twinagle/codegen/ServerClientCodeGenerator.scala
@@ -43,7 +43,8 @@ object ServerClientCodeGenerator extends CodeGenApp {
           for {
             file        <- request.filesToGenerate
             serviceFile <- generateServiceFiles(file, implicits)
-          } yield serviceFile
+          } yield serviceFile,
+          supportedFeatures = Set(CodeGeneratorResponse.Feature.FEATURE_PROTO3_OPTIONAL)
         )
       case Left(error) =>
         CodeGenResponse.fail(error)

--- a/codegen/src/sbt-test/generator/e2e/src/main/protobuf/optional_fields.proto
+++ b/codegen/src/sbt-test/generator/e2e/src/main/protobuf/optional_fields.proto
@@ -1,0 +1,14 @@
+// A small test case for support of optional fields in proto3.
+
+syntax = "proto3";
+
+package proto.test;
+
+message IHaveOptionalFields {
+  optional int32 maybe_int = 1;
+  optional string maybe_string = 2;
+}
+
+service OptionalFieldsTest {
+  rpc DoSomething(IHaveOptionalFields) returns (IHaveOptionalFields);
+}

--- a/codegen/src/sbt-test/generator/e2e/src/test/scala/proto/test/OptionalFieldsSpec.scala
+++ b/codegen/src/sbt-test/generator/e2e/src/test/scala/proto/test/OptionalFieldsSpec.scala
@@ -15,8 +15,10 @@ class OptionalFieldsSpec extends Specification {
         Future.value(req)
       }
 
+      @annotation.nowarn
       private def iTakeAnOptionInt[T](a: T)(implicit ev: T =:= Option[Int]): Unit = ()
 
+      @annotation.nowarn
       private def iTakeAnOptionString[T](a: T)(implicit ev: T =:= Option[String]): Unit = ()
     }
 

--- a/codegen/src/sbt-test/generator/e2e/src/test/scala/proto/test/OptionalFieldsSpec.scala
+++ b/codegen/src/sbt-test/generator/e2e/src/test/scala/proto/test/OptionalFieldsSpec.scala
@@ -1,0 +1,31 @@
+package proto.test
+
+import com.twitter.util.Future
+import com.soundcloud.twinagle.ServerBuilder
+
+import org.specs2.mutable.Specification
+
+class OptionalFieldsSpec extends Specification {
+  // if this compiles, we're good
+  "Proto files with optional scalar values are generated correctly" in {
+    val svc = new OptionalFieldsTestService {
+      override def doSomething(req: IHaveOptionalFields): Future[IHaveOptionalFields] = {
+        iTakeAnOptionInt(req.maybeInt)
+        iTakeAnOptionString(req.maybeString)
+        Future.value(req)
+      }
+
+      private def iTakeAnOptionInt(a: Option[Int]): Unit = ()
+
+      private def iTakeAnOptionString(a: Option[String]): Unit = ()
+    }
+
+    val httpService = ServerBuilder()
+      .register(svc)
+      .build
+
+    new OptionalFieldsTestClientProtobuf(httpService)
+    new OptionalFieldsTestClientJson(httpService)
+    ok
+  }
+}

--- a/codegen/src/sbt-test/generator/e2e/src/test/scala/proto/test/OptionalFieldsSpec.scala
+++ b/codegen/src/sbt-test/generator/e2e/src/test/scala/proto/test/OptionalFieldsSpec.scala
@@ -15,9 +15,9 @@ class OptionalFieldsSpec extends Specification {
         Future.value(req)
       }
 
-      private def iTakeAnOptionInt(a: Option[Int]): Unit = ()
+      private def iTakeAnOptionInt[T](a: T)(implicit ev: T =:= Option[Int]): Unit = ()
 
-      private def iTakeAnOptionString(a: Option[String]): Unit = ()
+      private def iTakeAnOptionString[T](a: T)(implicit ev: T =:= Option[String]): Unit = ()
     }
 
     val httpService = ServerBuilder()

--- a/codegen/src/sbt-test/generator/e2e/src/test/scala/twitch/twirp/example/haberdasher/HaberdasherSpec.scala
+++ b/codegen/src/sbt-test/generator/e2e/src/test/scala/twitch/twirp/example/haberdasher/HaberdasherSpec.scala
@@ -14,7 +14,7 @@ class HaberdasherSpec extends Specification {
           Hat(
             size = size.inches,
             color = "brown",
-            name = "bowler"
+            name = "bowler",
           )
         )
       } else {


### PR DESCRIPTION
Since protoc 3.15, proto3 files have had support for the `optional` keyword, which can be used with scalar fields to achieve nullability.

Our underlying code generator already supported this, we just needed to return the feature in order to indicate support in our `CodeGenApp`.
