### PR TITLE
TwinagleException includes error code in message

### DIFF
--- a/runtime/src/main/scala/com/soundcloud/twinagle/TwinagleException.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/TwinagleException.scala
@@ -80,7 +80,7 @@ object ErrorCode {
 }
 
 object TwinagleException {
-  def mkMessage(code: ErrorCode, msg: String): String = s"TwinagleException with errorCode ${code.desc}: $msg"
+  private def mkMessage(code: ErrorCode, msg: String): String = s"$msg [${code.desc}]"
 }
 
 case class TwinagleException(

--- a/runtime/src/main/scala/com/soundcloud/twinagle/TwinagleException.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/TwinagleException.scala
@@ -79,12 +79,16 @@ object ErrorCode {
   }
 }
 
+object TwinagleException {
+  def mkMessage(code: ErrorCode, msg: String): String = s"TwinagleException with errorCode ${code.desc}: $msg"
+}
+
 case class TwinagleException(
     code: ErrorCode,
     msg: String,
     meta: Map[String, String] = Map.empty,
     cause: Throwable = null
-) extends RuntimeException(msg, cause) {
+) extends RuntimeException(TwinagleException.mkMessage(code, msg), cause) {
   def this(cause: Throwable) =
     this(ErrorCode.Internal, cause.toString, Map.empty, cause)
 }

--- a/runtime/src/test/scala/com/soundcloud/twinagle/TwinagleExceptionSpec.scala
+++ b/runtime/src/test/scala/com/soundcloud/twinagle/TwinagleExceptionSpec.scala
@@ -7,8 +7,9 @@ class TwinagleExceptionSpec extends Specification {
 
   "TwinagleException when seen as a RuntimeException, message should contain the error code" in {
     val twinagleException = TwinagleException(ErrorCode.Internal, "something went wrong")
-    twinagleException.getMessage ==== "TwinagleException with errorCode internal: something went wrong"
+    twinagleException.getMessage ==== "something went wrong [internal]"
   }
+
   "specs2 throwsA(someTwinagleException) fails if someTwinagleException has different error code" in {
     val internalTwinagleException = TwinagleException(ErrorCode.Internal, "my error message")
     val expectedException         = TwinagleException(ErrorCode.NotFound, "my error message")

--- a/runtime/src/test/scala/com/soundcloud/twinagle/TwinagleExceptionSpec.scala
+++ b/runtime/src/test/scala/com/soundcloud/twinagle/TwinagleExceptionSpec.scala
@@ -1,0 +1,19 @@
+package com.soundcloud.twinagle
+
+import org.specs2.matcher.ResultMatchers.beFailing
+import org.specs2.mutable.Specification
+
+class TwinagleExceptionSpec extends Specification {
+
+  "TwinagleException when seen as a RuntimeException, message should contain the error code" in {
+    val twinagleException = TwinagleException(ErrorCode.Internal, "something went wrong")
+    twinagleException.getMessage ==== "TwinagleException with errorCode internal: something went wrong"
+  }
+  "specs2 throwsA(someTwinagleException) fails if someTwinagleException has different error code" in {
+    val internalTwinagleException = TwinagleException(ErrorCode.Internal, "my error message")
+    val expectedException         = TwinagleException(ErrorCode.NotFound, "my error message")
+    def myFunction(): Unit        = throw internalTwinagleException
+    (myFunction() must throwA(expectedException)) must beFailing
+  }
+
+}


### PR DESCRIPTION
When a `TwinagleException` is used as a `RuntimeException`, the `message` should still show the `errorCode` because often this has the most important information encoded.
This came up for me because spec2's `ExceptionMatcher` only verifies equality of type and of message, but it might also be relevant in other contexts.

Wrt releasing and semantic versioning, I think in edge cases this change could break clients if they parse the `message` to decide what to do next and look for equality of the strings.