### PR TITLE
record Twirp service/rpc as ServiceName/Rpc annotations

### DIFF
--- a/runtime/src/main/scala/com/soundcloud/twinagle/TracingFilter.scala
+++ b/runtime/src/main/scala/com/soundcloud/twinagle/TracingFilter.scala
@@ -9,6 +9,8 @@ private[twinagle] class TracingFilter[In, Out](
 ) extends SimpleFilter[In, Out] {
   override def apply(request: In, service: Service[In, Out]): Future[Out] = {
     val trace = Trace()
+    trace.recordServiceName(endpointMetadata.service)
+    trace.recordRpc(endpointMetadata.rpc)
     trace.recordBinary(TracingFilter.Service, endpointMetadata.service)
     trace.recordBinary(TracingFilter.Rpc, endpointMetadata.rpc)
 

--- a/runtime/src/test/scala/com/soundcloud/twinagle/TracingFilterSpec.scala
+++ b/runtime/src/test/scala/com/soundcloud/twinagle/TracingFilterSpec.scala
@@ -30,6 +30,8 @@ class TracingFilterSpec extends Specification {
         Await.result(svc(request))
       }
 
+      tracer.map(_.annotation) must contain(Annotation.Rpc("rpc"))
+      tracer.map(_.annotation) must contain(Annotation.ServiceName("svc"))
       binaryAnnotations.get(TracingFilter.Service) ==== Some("svc")
       binaryAnnotations.get(TracingFilter.Rpc) ==== Some("rpc")
 


### PR DESCRIPTION
finagle's HttpTracingFilter only records the HTTP method
as the Rpc annotation (I'm not sure what it records
for the Service). In any case, this seems more useful 🤔
