### PR TITLE
Revert to json4s

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,6 +50,7 @@ lazy val runtime = (project in file("runtime")).settings(
       "com.twitter"          %% "finagle-http"    % "24.2.0" cross CrossVersion.for3Use2_13,
       "com.thesamet.scalapb" %% "scalapb-runtime" % "0.11.17",
       "com.thesamet.scalapb" %% "scalapb-json4s"  % "0.12.1",
+      "org.json4s"           %% "json4s-native"   % "4.0.7",
       "org.specs2"           %% "specs2-core"     % "4.20.8" % Test cross CrossVersion.for3Use2_13
     )
   },
@@ -57,17 +58,14 @@ lazy val runtime = (project in file("runtime")).settings(
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, 13)) | Some((2, 12)) =>
         Seq(
-          "org.json4s" %% "json4s-native" % "4.0.7",
-          "org.specs2" %% "specs2-mock"   % "4.20.8" % Test
+          "org.specs2" %% "specs2-mock" % "4.20.8" % Test
         )
       case Some((3, 3)) =>
         Seq(
-          "org.playframework" %% "play-json" % "3.0.4",
           "org.scalamock"     %% "scalamock" % "6.1.1" % Test
         )
       case Some((3, _)) =>
         Seq(
-          "org.playframework" %% "play-json" % "3.0.4",
           "org.scalamock"     %% "scalamock" % "7.1.0" % Test
         )
       case _ => Seq.empty

--- a/runtime/src/main/scala-3/com/soundcloud/twinagle/JsonError.scala
+++ b/runtime/src/main/scala-3/com/soundcloud/twinagle/JsonError.scala
@@ -1,7 +1,5 @@
 package com.soundcloud.twinagle
 
-import play.api.libs.json.{Json, OFormat}
-
 /** JsonError is the JSON representation of `TwinagleException`s.
   *
   * If only there were some Language we could use to Define these kind of Interfaces
@@ -14,13 +12,21 @@ private[twinagle] case class JsonError(
 )
 
 private[twinagle] object JsonError {
+  import org.json4s.*
+  import org.json4s.native.Serialization
+  import org.json4s.native.Serialization.{read, write}
+
+  import scala.annotation.nowarn
   import scala.util.control.Exception.*
+  implicit val formats: AnyRef & Formats = Serialization.formats(NoTypeHints)
 
-  implicit val _format: OFormat[JsonError] = Json.format[JsonError]
-
+  // known issue in json4s wrt Manifest usage that has been deprecated in scala3
+  // will suppress this deprecation warning until this is fixed
+  // https://github.com/json4s/json4s/issues/982
+  @nowarn("cat=deprecation")
   def fromString(str: String): Option[JsonError] = allCatch opt {
-    Json.parse(str).as[JsonError]
+    read[JsonError](str)
   }
 
-  def toString(err: JsonError): String = Json.stringify(Json.toJson(err))
+  def toString(err: JsonError): String = write(err)
 }


### PR DESCRIPTION
in order to prevent diamond dependencies with finagle we will continue to use json4s with a nowarn suppression. 