### PR TITLE
Build and publish only LTS scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,7 @@ import sbt.CrossVersion
 
 lazy val scala212  = "2.12.18"
 lazy val scala213  = "2.13.14"
-lazy val scala3LTS = "3.3.4"
-lazy val scala3    = "3.6.3"
+lazy val scala3LTS = "3.3.5"
 
 lazy val commonSettings = List(
   scalaVersion := scala212,
@@ -42,7 +41,8 @@ lazy val codegen = (project in file("codegen"))
 lazy val runtime = (project in file("runtime")).settings(
   commonSettings,
   name               := "twinagle-runtime",
-  crossScalaVersions := Seq(scala212, scala213, scala3LTS, scala3),
+  crossScalaVersions := Seq(scala212, scala213, scala3LTS),
+  crossPaths := true,
   // finagle uses 2.13 heavily so we will ignore our project runtime compat
   excludeDependencies += "org.scala-lang.modules" % "scala-collection-compat_3",
   libraryDependencies ++= {
@@ -50,7 +50,7 @@ lazy val runtime = (project in file("runtime")).settings(
       "com.twitter"          %% "finagle-http"    % "24.2.0" cross CrossVersion.for3Use2_13,
       "com.thesamet.scalapb" %% "scalapb-runtime" % "0.11.17",
       "com.thesamet.scalapb" %% "scalapb-json4s"  % "0.12.1",
-      "org.json4s"           %% "json4s-native"   % "4.0.7",
+      "org.json4s"             %% "json4s-native"   % "4.0.7",
       "org.specs2"           %% "specs2-core"     % "4.20.8" % Test cross CrossVersion.for3Use2_13
     )
   },

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,6 @@ lazy val runtime = (project in file("runtime")).settings(
   commonSettings,
   name               := "twinagle-runtime",
   crossScalaVersions := Seq(scala212, scala213, scala3LTS),
-  crossPaths := true,
   // finagle uses 2.13 heavily so we will ignore our project runtime compat
   excludeDependencies += "org.scala-lang.modules" % "scala-collection-compat_3",
   libraryDependencies ++= {
@@ -50,7 +49,7 @@ lazy val runtime = (project in file("runtime")).settings(
       "com.twitter"          %% "finagle-http"    % "24.2.0" cross CrossVersion.for3Use2_13,
       "com.thesamet.scalapb" %% "scalapb-runtime" % "0.11.17",
       "com.thesamet.scalapb" %% "scalapb-json4s"  % "0.12.1",
-      "org.json4s"             %% "json4s-native"   % "4.0.7",
+      "org.json4s"           %% "json4s-native"   % "4.0.7",
       "org.specs2"           %% "specs2-core"     % "4.20.8" % Test cross CrossVersion.for3Use2_13
     )
   },
@@ -62,23 +61,13 @@ lazy val runtime = (project in file("runtime")).settings(
         )
       case Some((3, 3)) =>
         Seq(
-          "org.scalamock"     %% "scalamock" % "6.1.1" % Test
-        )
-      case Some((3, _)) =>
-        Seq(
-          "org.scalamock"     %% "scalamock" % "7.1.0" % Test
+          "org.scalamock" %% "scalamock" % "6.1.1" % Test
         )
       case _ => Seq.empty
     }
   },
   // compile protobuf messages for unit tests
   Project.inConfig(Test)(sbtprotoc.ProtocPlugin.protobufConfigSettings),
-  Test / scalacOptions += {
-    CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((3, minor)) if minor > 3 => "-experimental"
-      case _                             => ""
-    }
-  },
   Test / PB.targets := {
     val gen3 = CrossVersion.partialVersion(scalaVersion.value).exists(a => a._1 == 3L)
     Seq(


### PR DESCRIPTION
declaring 3 scala minor versions always takes the latest when projects pull in the dependency. this causes issue as the TASTy reader is always looking at the latest binary (in this 3.6.3) so runtimes cause incompatibility errors.  if developers wish to use 3.6.3, twinagle will still compile for them when its built with 3.3.x. 

This also reduces some complexity in the tests configuration as we dont need to manage 2 versions of scalamock 

also handles #451 