### PR TITLE
chore: remove debug log line

### DIFF
--- a/codegen/src/main/scala/com/soundcloud/twinagle/codegen/ServerClientCodeGenerator.scala
+++ b/codegen/src/main/scala/com/soundcloud/twinagle/codegen/ServerClientCodeGenerator.scala
@@ -46,7 +46,6 @@ trait ServerClientCodeGenerator extends CodeGenApp {
       val b    = CodeGeneratorResponse.File.newBuilder()
       b.setName(file.scalaDirectory + "/" + service.name + ".scala")
       b.setContent(code)
-      println(b.getName)
       b.build
     }
   }


### PR DESCRIPTION
I'm not sure if this log line is intentional or if it's a relic from debugging. However, it spams outputs when generating a lot of proto files. If we really want to print debug info, we should do it in a structured format rather than just using `println`.