### PR TITLE
chore(deps): upgrade sbt and sbt-ci-release plugin

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.7
+sbt.version=1.11.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.5")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
 
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.9.2")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.2")
 
 libraryDependencies ++= Seq(
   "org.scala-sbt"        %% "scripted-plugin" % sbtVersion.value,


### PR DESCRIPTION
We need new versions to publish to Sonatype Central per the [notice](https://github.com/sbt/sbt-ci-release?tab=readme-ov-file#sbt-ci-release) in sbt-ci-release:

> Note: Sonatype has [sunset the Legacy OSSRH endpoint to publish](https://central.sonatype.org/news/20250326_ossrh_sunset/) on 2025-06-30. To publish to the Central Repository, please migrate to sbt 1.11.x or later and sbt-ci-release 1.11.0 or later after you migrate to publish to the Central Portal publishing.